### PR TITLE
refactor(typography): #11 create SASS placeholders for typescale styles

### DIFF
--- a/packages/ui-js/css/base/copy.scss
+++ b/packages/ui-js/css/base/copy.scss
@@ -1,67 +1,28 @@
+@import "../component";
+
 h1, h2, h3, h4, h5, h6, figure {
   margin: 0;
 }
 
 h1,
-.ez-h1 {
-  font-family: var(--md-sys-typescale-display-large-font, inherit);
-  font-size: var(--md-sys-typescale-display-large-size, 4.75rem);
-  font-weight: var(--md-sys-typescale-display-large-weight, 400);
-  line-height: var(--md-sys-typescale-display-large-line-height, 5.33333rem);
-  letter-spacing: var(--md-sys-typescale-display-large-tracking, 0);
-}
+.ez-h1 { @extend %md-typescale-display-large; }
 
 h2,
-.ez-h2 {
-  font-family: var(--md-sys-typescale-headline-large-font, inherit);
-  font-size: var(--md-sys-typescale-headline-large-size, 2.66667rem);
-  font-weight: var(--md-sys-typescale-headline-large-weight, 400);
-  line-height: var(--md-sys-typescale-headline-large-line-height, 3.33333rem);
-  letter-spacing: var(--md-sys-typescale-headline-large-tracking, 0);
-}
+.ez-h2 { @extend %md-typescale-headline-large; }
 
 h3,
-.ez-h3 {
-  font-family: var(--md-sys-typescale-headline-medium-font, inherit);
-  font-size: var(--md-sys-typescale-headline-medium-size, 2.33333rem);
-  font-weight: var(--md-sys-typescale-headline-medium-weight, 400);
-  line-height: var(--md-sys-typescale-headline-medium-line-height, 3rem);
-  letter-spacing: var(--md-sys-typescale-headline-medium-tracking, 0);
-}
+.ez-h3 { @extend %md-typescale-headline-medium; }
 
 h4,
-.ez-h4 {
-  font-family: var(--md-sys-typescale-headline-small-font, inherit);
-  font-size: var(--md-sys-typescale-headline-small-size, 2rem);
-  font-weight: var(--md-sys-typescale-headline-small-weight, 400);
-  line-height: var(--md-sys-typescale-headline-small-line-height, 2.66667rem);
-  letter-spacing: var(--md-sys-typescale-headline-small-tracking, 0);
-}
+.ez-h4 { @extend %md-typescale-headline-small; }
 
 h5,
-.ez-h5 {
-  font-family: var(--md-sys-typescale-title-large-font, inherit);
-  font-size: var(--md-sys-typescale-title-large-size, 1.83333rem);
-  font-weight: var(--md-sys-typescale-title-large-weight, 400);
-  line-height: var(--md-sys-typescale-title-large-line-height, 2.33333rem);
-  letter-spacing: var(--md-sys-typescale-title-large-tracking, 0);
-}
+.ez-h5 { @extend %md-typescale-title-large; }
 
 h6,
-.ez-h6 {
-  font-family: var(--md-sys-typescale-title-medium-font, inherit);
-  font-size: var(--md-sys-typescale-title-medium-size, 1.33333rem);
-  font-weight: var(--md-sys-typescale-title-medium-weight, 500);
-  line-height: var(--md-sys-typescale-title-medium-line-height, 2rem);
-  letter-spacing: var(--md-sys-typescale-title-medium-tracking, 0);
-}
+.ez-h6 { @extend %md-typescale-title-medium; }
 
-a, p {
-  font-size: var(--md-sys-typescale-body-large-size, 1.33333rem);
-  font-weight: var(--md-sys-typescale-body-large-weight, 400);
-  line-height: var(--md-sys-typescale-body-large-line-height, 2rem);
-  letter-spacing: var(--md-sys-typescale-body-large-tracking, 0);
-}
+a, p { @extend %md-typescale-body-large; }
 
 dl dd + *,
 dl dt + *,

--- a/packages/ui-js/css/base/typography.scss
+++ b/packages/ui-js/css/base/typography.scss
@@ -10,6 +10,8 @@
  * Values converted from M3 spec pt to px via 1 pt = 4/3 px, expressed as rem.
  */
 
+@import "../component";
+
 :root {
   /* ========================================
    * Display
@@ -144,126 +146,26 @@
  * ======================================== */
 
 /* Display */
-.md-typescale-display-large {
-  font-family: var(--md-sys-typescale-display-large-font), sans-serif;
-  font-size: var(--md-sys-typescale-display-large-size);
-  font-weight: var(--md-sys-typescale-display-large-weight);
-  line-height: var(--md-sys-typescale-display-large-line-height);
-  letter-spacing: var(--md-sys-typescale-display-large-tracking);
-}
-
-.md-typescale-display-medium {
-  font-family: var(--md-sys-typescale-display-medium-font), sans-serif;
-  font-size: var(--md-sys-typescale-display-medium-size);
-  font-weight: var(--md-sys-typescale-display-medium-weight);
-  line-height: var(--md-sys-typescale-display-medium-line-height);
-  letter-spacing: var(--md-sys-typescale-display-medium-tracking);
-}
-
-.md-typescale-display-small {
-  font-family: var(--md-sys-typescale-display-small-font), sans-serif;
-  font-size: var(--md-sys-typescale-display-small-size);
-  font-weight: var(--md-sys-typescale-display-small-weight);
-  line-height: var(--md-sys-typescale-display-small-line-height);
-  letter-spacing: var(--md-sys-typescale-display-small-tracking);
-}
+.md-typescale-display-large { @extend %md-typescale-display-large; }
+.md-typescale-display-medium { @extend %md-typescale-display-medium; }
+.md-typescale-display-small { @extend %md-typescale-display-small; }
 
 /* Headline */
-.md-typescale-headline-large {
-  font-family: var(--md-sys-typescale-headline-large-font), sans-serif;
-  font-size: var(--md-sys-typescale-headline-large-size);
-  font-weight: var(--md-sys-typescale-headline-large-weight);
-  line-height: var(--md-sys-typescale-headline-large-line-height);
-  letter-spacing: var(--md-sys-typescale-headline-large-tracking);
-}
-
-.md-typescale-headline-medium {
-  font-family: var(--md-sys-typescale-headline-medium-font), sans-serif;
-  font-size: var(--md-sys-typescale-headline-medium-size);
-  font-weight: var(--md-sys-typescale-headline-medium-weight);
-  line-height: var(--md-sys-typescale-headline-medium-line-height);
-  letter-spacing: var(--md-sys-typescale-headline-medium-tracking);
-}
-
-.md-typescale-headline-small {
-  font-family: var(--md-sys-typescale-headline-small-font), sans-serif;
-  font-size: var(--md-sys-typescale-headline-small-size);
-  font-weight: var(--md-sys-typescale-headline-small-weight);
-  line-height: var(--md-sys-typescale-headline-small-line-height);
-  letter-spacing: var(--md-sys-typescale-headline-small-tracking);
-}
+.md-typescale-headline-large { @extend %md-typescale-headline-large; }
+.md-typescale-headline-medium { @extend %md-typescale-headline-medium; }
+.md-typescale-headline-small { @extend %md-typescale-headline-small; }
 
 /* Title */
-.md-typescale-title-large {
-  font-family: var(--md-sys-typescale-title-large-font), sans-serif;
-  font-size: var(--md-sys-typescale-title-large-size);
-  font-weight: var(--md-sys-typescale-title-large-weight);
-  line-height: var(--md-sys-typescale-title-large-line-height);
-  letter-spacing: var(--md-sys-typescale-title-large-tracking);
-}
-
-.md-typescale-title-medium {
-  font-family: var(--md-sys-typescale-title-medium-font), sans-serif;
-  font-size: var(--md-sys-typescale-title-medium-size);
-  font-weight: var(--md-sys-typescale-title-medium-weight);
-  line-height: var(--md-sys-typescale-title-medium-line-height);
-  letter-spacing: var(--md-sys-typescale-title-medium-tracking);
-}
-
-.md-typescale-title-small {
-  font-family: var(--md-sys-typescale-title-small-font), sans-serif;
-  font-size: var(--md-sys-typescale-title-small-size);
-  font-weight: var(--md-sys-typescale-title-small-weight);
-  line-height: var(--md-sys-typescale-title-small-line-height);
-  letter-spacing: var(--md-sys-typescale-title-small-tracking);
-}
+.md-typescale-title-large { @extend %md-typescale-title-large; }
+.md-typescale-title-medium { @extend %md-typescale-title-medium; }
+.md-typescale-title-small { @extend %md-typescale-title-small; }
 
 /* Body */
-.md-typescale-body-large {
-  font-family: var(--md-sys-typescale-body-large-font), sans-serif;
-  font-size: var(--md-sys-typescale-body-large-size);
-  font-weight: var(--md-sys-typescale-body-large-weight);
-  line-height: var(--md-sys-typescale-body-large-line-height);
-  letter-spacing: var(--md-sys-typescale-body-large-tracking);
-}
-
-.md-typescale-body-medium {
-  font-family: var(--md-sys-typescale-body-medium-font), sans-serif;
-  font-size: var(--md-sys-typescale-body-medium-size);
-  font-weight: var(--md-sys-typescale-body-medium-weight);
-  line-height: var(--md-sys-typescale-body-medium-line-height);
-  letter-spacing: var(--md-sys-typescale-body-medium-tracking);
-}
-
-.md-typescale-body-small {
-  font-family: var(--md-sys-typescale-body-small-font), sans-serif;
-  font-size: var(--md-sys-typescale-body-small-size);
-  font-weight: var(--md-sys-typescale-body-small-weight);
-  line-height: var(--md-sys-typescale-body-small-line-height);
-  letter-spacing: var(--md-sys-typescale-body-small-tracking);
-}
+.md-typescale-body-large { @extend %md-typescale-body-large; }
+.md-typescale-body-medium { @extend %md-typescale-body-medium; }
+.md-typescale-body-small { @extend %md-typescale-body-small; }
 
 /* Label */
-.md-typescale-label-large {
-  font-family: var(--md-sys-typescale-label-large-font), sans-serif;
-  font-size: var(--md-sys-typescale-label-large-size);
-  font-weight: var(--md-sys-typescale-label-large-weight);
-  line-height: var(--md-sys-typescale-label-large-line-height);
-  letter-spacing: var(--md-sys-typescale-label-large-tracking);
-}
-
-.md-typescale-label-medium {
-  font-family: var(--md-sys-typescale-label-medium-font), sans-serif;
-  font-size: var(--md-sys-typescale-label-medium-size);
-  font-weight: var(--md-sys-typescale-label-medium-weight);
-  line-height: var(--md-sys-typescale-label-medium-line-height);
-  letter-spacing: var(--md-sys-typescale-label-medium-tracking);
-}
-
-.md-typescale-label-small {
-  font-family: var(--md-sys-typescale-label-small-font), sans-serif;
-  font-size: var(--md-sys-typescale-label-small-size);
-  font-weight: var(--md-sys-typescale-label-small-weight);
-  line-height: var(--md-sys-typescale-label-small-line-height);
-  letter-spacing: var(--md-sys-typescale-label-small-tracking);
-}
+.md-typescale-label-large { @extend %md-typescale-label-large; }
+.md-typescale-label-medium { @extend %md-typescale-label-medium; }
+.md-typescale-label-small { @extend %md-typescale-label-small; }

--- a/packages/ui-js/css/component.scss
+++ b/packages/ui-js/css/component.scss
@@ -1,0 +1,7 @@
+/**
+ * component.scss
+ *
+ * Convenience barrel for component SCSS files.
+ * Import this single file to access all shared SASS placeholders and mixins.
+ */
+@import "placeholders/typescale";

--- a/packages/ui-js/css/modules/dialog/dialog.scss
+++ b/packages/ui-js/css/modules/dialog/dialog.scss
@@ -1,3 +1,5 @@
+@import "../../component";
+
 /**
  * dialog.css
  *
@@ -66,11 +68,8 @@
  * ======================================== */
 
 .ez-dialog__headline {
-  font-family: var(--md-sys-typescale-headline-small-font, inherit);
-  font-size: var(--md-sys-typescale-headline-small-size, 2rem);
-  font-weight: var(--md-sys-typescale-headline-small-weight, 400);
-  line-height: var(--md-sys-typescale-headline-small-line-height, 2.66667rem);
-  letter-spacing: var(--md-sys-typescale-headline-small-tracking, 0);
+  @extend %md-typescale-headline-small;
+
   color: var(--md-sys-color-on-surface, CanvasText);
   padding: var(--md-sys-spacing-6, 1.5rem) var(--md-sys-spacing-6, 1.5rem) 0;
   margin: 0;
@@ -103,11 +102,8 @@
  * ======================================== */
 
 .ez-dialog__content {
-  font-family: var(--md-sys-typescale-body-medium-font, inherit);
-  font-size: var(--md-sys-typescale-body-medium-size, 1.16667rem);
-  font-weight: var(--md-sys-typescale-body-medium-weight, 400);
-  line-height: var(--md-sys-typescale-body-medium-line-height, 1.66667rem);
-  letter-spacing: var(--md-sys-typescale-body-medium-tracking, 0);
+  @extend %md-typescale-body-medium;
+
   color: var(--md-sys-color-on-surface-variant, GrayText);
   padding: var(--md-sys-spacing-6, 1.5rem);
   overflow-y: auto;
@@ -232,11 +228,8 @@
 }
 
 .ez-dialog__header .ez-dialog__headline {
-  font-family: var(--md-sys-typescale-title-large-font, inherit);
-  font-size: var(--md-sys-typescale-title-large-size, 1.83333rem);
-  font-weight: var(--md-sys-typescale-title-large-weight, 400);
-  line-height: var(--md-sys-typescale-title-large-line-height, 2.33333rem);
-  letter-spacing: var(--md-sys-typescale-title-large-tracking, 0);
+  @extend %md-typescale-title-large;
+
   flex: 1;
   padding: 0;
   margin: 0;

--- a/packages/ui-js/css/placeholders/_typescale.scss
+++ b/packages/ui-js/css/placeholders/_typescale.scss
@@ -1,0 +1,150 @@
+/**
+ * _typescale.scss
+ *
+ * SASS placeholder selectors for Material Design 3 typescale styles.
+ * 5 roles (display, headline, title, body, label) × 3 sizes (large, medium, small)
+ * = 15 placeholders.
+ *
+ * Placeholders own their fallback values.  Call-sites use `@extend` and
+ * do *not* repeat fallbacks.
+ */
+
+/* ========================================
+ * Display
+ * ======================================== */
+
+%md-typescale-display-large {
+  font-family: var(--md-sys-typescale-display-large-font, roboto, system-ui, sans-serif);
+  font-size: var(--md-sys-typescale-display-large-size, 4.75rem);
+  font-weight: var(--md-sys-typescale-display-large-weight, 400);
+  line-height: var(--md-sys-typescale-display-large-line-height, 5.33333rem);
+  letter-spacing: var(--md-sys-typescale-display-large-tracking, 0);
+}
+
+%md-typescale-display-medium {
+  font-family: var(--md-sys-typescale-display-medium-font, roboto, system-ui, sans-serif);
+  font-size: var(--md-sys-typescale-display-medium-size, 3.75rem);
+  font-weight: var(--md-sys-typescale-display-medium-weight, 400);
+  line-height: var(--md-sys-typescale-display-medium-line-height, 4.33333rem);
+  letter-spacing: var(--md-sys-typescale-display-medium-tracking, 0);
+}
+
+%md-typescale-display-small {
+  font-family: var(--md-sys-typescale-display-small-font, roboto, system-ui, sans-serif);
+  font-size: var(--md-sys-typescale-display-small-size, 3rem);
+  font-weight: var(--md-sys-typescale-display-small-weight, 400);
+  line-height: var(--md-sys-typescale-display-small-line-height, 3.66667rem);
+  letter-spacing: var(--md-sys-typescale-display-small-tracking, 0);
+}
+
+/* ========================================
+ * Headline
+ * ======================================== */
+
+%md-typescale-headline-large {
+  font-family: var(--md-sys-typescale-headline-large-font, roboto, system-ui, sans-serif);
+  font-size: var(--md-sys-typescale-headline-large-size, 2.66667rem);
+  font-weight: var(--md-sys-typescale-headline-large-weight, 400);
+  line-height: var(--md-sys-typescale-headline-large-line-height, 3.33333rem);
+  letter-spacing: var(--md-sys-typescale-headline-large-tracking, 0);
+}
+
+%md-typescale-headline-medium {
+  font-family: var(--md-sys-typescale-headline-medium-font, roboto, system-ui, sans-serif);
+  font-size: var(--md-sys-typescale-headline-medium-size, 2.33333rem);
+  font-weight: var(--md-sys-typescale-headline-medium-weight, 400);
+  line-height: var(--md-sys-typescale-headline-medium-line-height, 3rem);
+  letter-spacing: var(--md-sys-typescale-headline-medium-tracking, 0);
+}
+
+%md-typescale-headline-small {
+  font-family: var(--md-sys-typescale-headline-small-font, roboto, system-ui, sans-serif);
+  font-size: var(--md-sys-typescale-headline-small-size, 2rem);
+  font-weight: var(--md-sys-typescale-headline-small-weight, 400);
+  line-height: var(--md-sys-typescale-headline-small-line-height, 2.66667rem);
+  letter-spacing: var(--md-sys-typescale-headline-small-tracking, 0);
+}
+
+/* ========================================
+ * Title
+ * ======================================== */
+
+%md-typescale-title-large {
+  font-family: var(--md-sys-typescale-title-large-font, roboto, system-ui, sans-serif);
+  font-size: var(--md-sys-typescale-title-large-size, 1.83333rem);
+  font-weight: var(--md-sys-typescale-title-large-weight, 400);
+  line-height: var(--md-sys-typescale-title-large-line-height, 2.33333rem);
+  letter-spacing: var(--md-sys-typescale-title-large-tracking, 0);
+}
+
+%md-typescale-title-medium {
+  font-family: var(--md-sys-typescale-title-medium-font, roboto, system-ui, sans-serif);
+  font-size: var(--md-sys-typescale-title-medium-size, 1.33333rem);
+  font-weight: var(--md-sys-typescale-title-medium-weight, 500);
+  line-height: var(--md-sys-typescale-title-medium-line-height, 2rem);
+  letter-spacing: var(--md-sys-typescale-title-medium-tracking, 0);
+}
+
+%md-typescale-title-small {
+  font-family: var(--md-sys-typescale-title-small-font, roboto, system-ui, sans-serif);
+  font-size: var(--md-sys-typescale-title-small-size, 1.16667rem);
+  font-weight: var(--md-sys-typescale-title-small-weight, 500);
+  line-height: var(--md-sys-typescale-title-small-line-height, 1.66667rem);
+  letter-spacing: var(--md-sys-typescale-title-small-tracking, 0);
+}
+
+/* ========================================
+ * Body
+ * ======================================== */
+
+%md-typescale-body-large {
+  font-family: var(--md-sys-typescale-body-large-font, roboto, system-ui, sans-serif);
+  font-size: var(--md-sys-typescale-body-large-size, 1.33333rem);
+  font-weight: var(--md-sys-typescale-body-large-weight, 400);
+  line-height: var(--md-sys-typescale-body-large-line-height, 2rem);
+  letter-spacing: var(--md-sys-typescale-body-large-tracking, 0);
+}
+
+%md-typescale-body-medium {
+  font-family: var(--md-sys-typescale-body-medium-font, roboto, system-ui, sans-serif);
+  font-size: var(--md-sys-typescale-body-medium-size, 1.16667rem);
+  font-weight: var(--md-sys-typescale-body-medium-weight, 400);
+  line-height: var(--md-sys-typescale-body-medium-line-height, 1.66667rem);
+  letter-spacing: var(--md-sys-typescale-body-medium-tracking, 0);
+}
+
+%md-typescale-body-small {
+  font-family: var(--md-sys-typescale-body-small-font, roboto, system-ui, sans-serif);
+  font-size: var(--md-sys-typescale-body-small-size, 1rem);
+  font-weight: var(--md-sys-typescale-body-small-weight, 400);
+  line-height: var(--md-sys-typescale-body-small-line-height, 1.33333rem);
+  letter-spacing: var(--md-sys-typescale-body-small-tracking, 0.00833rem);
+}
+
+/* ========================================
+ * Label
+ * ======================================== */
+
+%md-typescale-label-large {
+  font-family: var(--md-sys-typescale-label-large-font, roboto, system-ui, sans-serif);
+  font-size: var(--md-sys-typescale-label-large-size, 1.16667rem);
+  font-weight: var(--md-sys-typescale-label-large-weight, 500);
+  line-height: var(--md-sys-typescale-label-large-line-height, 1.66667rem);
+  letter-spacing: var(--md-sys-typescale-label-large-tracking, 0);
+}
+
+%md-typescale-label-medium {
+  font-family: var(--md-sys-typescale-label-medium-font, roboto, system-ui, sans-serif);
+  font-size: var(--md-sys-typescale-label-medium-size, 1rem);
+  font-weight: var(--md-sys-typescale-label-medium-weight, 500);
+  line-height: var(--md-sys-typescale-label-medium-line-height, 1.33333rem);
+  letter-spacing: var(--md-sys-typescale-label-medium-tracking, 0.00833rem);
+}
+
+%md-typescale-label-small {
+  font-family: var(--md-sys-typescale-label-small-font, roboto, system-ui, sans-serif);
+  font-size: var(--md-sys-typescale-label-small-size, 0.91667rem);
+  font-weight: var(--md-sys-typescale-label-small-weight, 500);
+  line-height: var(--md-sys-typescale-label-small-line-height, 1.33333rem);
+  letter-spacing: var(--md-sys-typescale-label-small-tracking, 0.00833rem);
+}

--- a/packages/ui-js/ez-appbar/index.scss
+++ b/packages/ui-js/ez-appbar/index.scss
@@ -1,3 +1,5 @@
+@import "../css/component";
+
 /* ========================================
  * Base appbar styles (common to all sizes)
  * ======================================== */
@@ -57,21 +59,15 @@
 
 :where(.ez-appbar, ez-appbar):not([class^="ez-theme"], [class*=" ez-theme"]),
 :where(.ez-appbar, ez-appbar):not(.ez-medium, .ez-large) :is(h1, h2, h3, h4, h5, h6, .ez-appbar-title) {
-  font-family: var(--md-sys-typescale-title-large-font), sans-serif;
-  font-size: var(--md-sys-typescale-title-large-size);
-  font-weight: var(--md-sys-typescale-title-large-weight);
-  line-height: var(--md-sys-typescale-title-large-line-height);
-  letter-spacing: var(--md-sys-typescale-title-large-tracking);
+  @extend %md-typescale-title-large;
+
   margin: 0;
 }
 
 :where(.ez-appbar, ez-appbar):not([class^="ez-theme"], [class*=" ez-theme"]),
 :where(.ez-appbar, ez-appbar):not(.ez-medium, .ez-large) :is(p, .ez-appbar-subtitle) {
-  font-family: var(--md-sys-typescale-label-medium-font), sans-serif;
-  font-size: var(--md-sys-typescale-label-medium-size);
-  font-weight: var(--md-sys-typescale-label-medium-weight);
-  line-height: var(--md-sys-typescale-label-medium-line-height);
-  letter-spacing: var(--md-sys-typescale-label-medium-tracking);
+  @extend %md-typescale-label-medium;
+
   margin: 0;
 }
 
@@ -91,20 +87,14 @@
 }
 
 :where(.ez-appbar, ez-appbar).ez-medium :is(h1, h2, h3, h4, h5, h6, .ez-appbar-title) {
-  font-family: var(--md-sys-typescale-headline-medium-font), sans-serif;
-  font-size: var(--md-sys-typescale-headline-medium-size);
-  font-weight: var(--md-sys-typescale-headline-medium-weight);
-  line-height: var(--md-sys-typescale-headline-medium-line-height);
-  letter-spacing: var(--md-sys-typescale-headline-medium-tracking);
+  @extend %md-typescale-headline-medium;
+
   margin: 0;
 }
 
 :where(.ez-appbar, ez-appbar).ez-medium :is(p, .ez-appbar-subtitle) {
-  font-family: var(--md-sys-typescale-title-small-font), sans-serif;
-  font-size: var(--md-sys-typescale-title-small-size);
-  font-weight: var(--md-sys-typescale-title-small-weight);
-  line-height: var(--md-sys-typescale-title-small-line-height);
-  letter-spacing: var(--md-sys-typescale-title-small-tracking);
+  @extend %md-typescale-title-small;
+
   margin: 0;
 }
 
@@ -124,20 +114,14 @@
 }
 
 :where(.ez-appbar, ez-appbar).ez-large :is(h1, h2, h3, h4, h5, h6, .ez-appbar-title) {
-  font-family: var(--md-sys-typescale-display-small-font), sans-serif;
-  font-size: var(--md-sys-typescale-display-small-size);
-  font-weight: var(--md-sys-typescale-display-small-weight);
-  line-height: var(--md-sys-typescale-display-small-line-height);
-  letter-spacing: var(--md-sys-typescale-display-small-tracking);
+  @extend %md-typescale-display-small;
+
   margin: 0;
 }
 
 :where(.ez-appbar, ez-appbar).ez-large :is(p, .ez-appbar-subtitle) {
-  font-family: var(--md-sys-typescale-title-medium-font), sans-serif;
-  font-size: var(--md-sys-typescale-title-medium-size);
-  font-weight: var(--md-sys-typescale-title-medium-weight);
-  line-height: var(--md-sys-typescale-title-medium-line-height);
-  letter-spacing: var(--md-sys-typescale-title-medium-tracking);
+  @extend %md-typescale-title-medium;
+
   margin: 0;
 }
 


### PR DESCRIPTION
## Summary

Closes #11

Introduces SASS `%placeholder` selectors for the 15 M3 typescale role×size combinations, eliminating duplicated 5-property font blocks across 10+ SCSS files.

## Changes

### New files
- **`css/placeholders/_typescale.scss`** — 15 `%placeholder` selectors (placeholders own `var()` fallbacks)
- **`css/component.scss`** — barrel file re-exporting shared SASS utilities for component SCSS imports

### Refactored (duplicate font blocks → `@extend`)
- **`css/base/typography.scss`** — 15 utility classes now `@extend` placeholders
- **`css/base/copy.scss`** — `h1`–`h6`, `a`/`p` use `@extend`
- **`css/modules/dialog/dialog.scss`** — headline, content, header headline use `@extend`
- **`ez-appbar/index.scss`** — title/subtitle at all 3 size variants use `@extend`

### Unchanged (partial call-sites)
Button sizes, list, input, and fieldset files use only a subset of typescale properties (e.g., just `font-size`), so they retain direct `var()` references rather than pulling in all 5 properties via `@extend`.

## Design decisions
- **Placeholders own fallbacks** — `var(--token, fallback)` lives in placeholders; call-sites do not repeat fallbacks
- **`css/component.scss` barrel** — components import one file to access all shared placeholders/mixins
- **TS→SCSS migration deferred** — `ez-button.styles.ts` and `ez-field.css.ts` inline CSS migration requires `rollup-plugin-sass` integration (separate follow-up)

## Verification
- ✅ All 112 tests pass
- ✅ Build succeeds
- ✅ Lint clean
