### PR TITLE
feat(ez-dialog): #31 Add dialog header examples with Tailwind flex + integrate Tailwind into Storybook

### DIFF
--- a/packages/ui/.storybook/preview.ts
+++ b/packages/ui/.storybook/preview.ts
@@ -1,4 +1,5 @@
 import type {Preview} from "@storybook/web-components-vite";
+import 'tailwindcss';
 import '../scss/roboto.scss';
 import '../scss/index.scss';
 import '../scss/material/symbol-icons-base.scss';

--- a/packages/ui/ez-dialog/index.stories.ts
+++ b/packages/ui/ez-dialog/index.stories.ts
@@ -871,3 +871,126 @@ export const WithThemes: StoryObj = {
     );
   },
 };
+
+export const DialogWithHeader: StoryObj = {
+  render: () => html`
+    <section>
+      <header><h2>Dialog with Header (Tailwind Flex)</h2></header>
+      <div class="ez-section-body">
+        <button
+          class="ez-btn ez-filled ez-theme-primary"
+          type="button"
+          @click=${() => {
+            openDialog('header-dialog');
+          }}
+        >
+          <ez-ripple></ez-ripple>
+          Open Dialog with Header
+        </button>
+
+        <dialog
+          class="ez-dialog"
+          id="header-dialog"
+          aria-labelledby="header-dialog-title"
+        >
+          <div class="flex flex-row items-center justify-between px-6 pt-6">
+            <h2
+              class="ez-dialog__headline"
+              id="header-dialog-title"
+              style="padding: 0; margin: 0;"
+            >
+              Dialog Title
+            </h2>
+            <button
+              class="ez-btn ez-icon-btn"
+              type="button"
+              aria-label="Close"
+              @click=${() => {
+                closeDialog('header-dialog');
+              }}
+            >
+              <ez-ripple></ez-ripple>
+              <span class="material-symbols-outlined" aria-hidden="true"
+                >close</span
+              >
+            </button>
+          </div>
+          <form
+            class="ez-dialog__content"
+            id="header-dialog-form"
+            method="dialog"
+          >
+            This dialog uses a header div with Tailwind flex utilities to
+            position the title and close button. The close button sits in the
+            upper-right corner via <code>justify-between</code>.
+          </form>
+          <div class="ez-dialog__actions">
+            <button
+              class="ez-btn ez-theme-primary"
+              form="header-dialog-form"
+              value="cancel"
+            >
+              <ez-ripple></ez-ripple>
+              Cancel
+            </button>
+            <button
+              class="ez-btn ez-filled ez-theme-primary"
+              form="header-dialog-form"
+              value="confirm"
+            >
+              <ez-ripple></ez-ripple>
+              Confirm
+            </button>
+          </div>
+        </dialog>
+      </div>
+    </section>
+  `,
+  play: async ({ canvasElement }) => {
+    const dialog =
+      canvasElement.querySelector<HTMLDialogElement>('#header-dialog');
+
+    if (!dialog) return;
+
+    await expect(dialog).toBeInTheDocument();
+    await expect(dialog).toHaveClass('ez-dialog');
+
+    // Verify header structure
+    const header = dialog.querySelector('div.flex');
+
+    await expect(header).toBeInTheDocument();
+    await expect(header).toHaveClass('flex-row');
+    await expect(header).toHaveClass('items-center');
+    await expect(header).toHaveClass('justify-between');
+
+    // Verify title is in header
+    const headline = header?.querySelector('.ez-dialog__headline');
+
+    await expect(headline).toBeInTheDocument();
+    await expect(headline?.textContent?.trim()).toBe('Dialog Title');
+
+    // Verify close button is in header
+    const closeBtn = header?.querySelector('button[aria-label="Close"]');
+
+    await expect(closeBtn).toBeInTheDocument();
+
+    // Verify content and actions
+    const content = dialog.querySelector('.ez-dialog__content');
+
+    await expect(content).toBeInTheDocument();
+
+    const actions = dialog.querySelector('.ez-dialog__actions');
+
+    await expect(actions).toBeInTheDocument();
+    await expect(actions?.children.length).toBe(2);
+
+    // Open and verify
+    dialog.showModal();
+    await expect(dialog).toHaveAttribute('open');
+
+    // Close via button and verify
+    dialog.close('confirm');
+    await expect(dialog.open).toBe(false);
+    await expect(dialog.returnValue).toBe('confirm');
+  },
+};

--- a/packages/ui/vite.config.ts
+++ b/packages/ui/vite.config.ts
@@ -1,6 +1,7 @@
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { defineConfig, type Plugin } from 'vite';
+import tailwindcss from '@tailwindcss/vite';
 import react from '@vitejs/plugin-react';
 import storybookTest from '@storybook/addon-vitest/vitest-plugin';
 import { playwright } from '@vitest/browser-playwright';
@@ -53,7 +54,7 @@ function componentScssPlugin(): Plugin {
 }
 
 export default defineConfig({
-  plugins: [componentScssPlugin(), react()],
+  plugins: [tailwindcss(), componentScssPlugin(), react()],
   resolve: {
     alias: {
       '@': dirname,


### PR DESCRIPTION
Closes #31

## Summary

Integrates Tailwind CSS v4 into Storybook and adds a new `DialogWithHeader` story example.

## Changes

### Tailwind in Storybook
- **`packages/ui/vite.config.ts`** — Added `@tailwindcss/vite` plugin so Storybook picks up Tailwind utilities
- **`packages/ui/.storybook/preview.ts`** — Added `import 'tailwindcss'` (Tailwind v4 CSS-first import)

### New Dialog Story
- **`packages/ui/ez-dialog/index.stories.ts`** — Added `DialogWithHeader` story:
  - Basic (non-fullscreen) dialog with a `<div>` header using Tailwind flex classes (`flex`, `flex-row`, `items-center`, `justify-between`)
  - Title + close button positioned in the upper-right corner
  - `play` function asserting header structure, Tailwind classes, and open/close behavior

## Notes
- Tailwind v4 was already installed (`tailwindcss@^4.2.1`, `@tailwindcss/vite@^4.2.1`) but not wired in — this PR activates it for Storybook only
- Production build is unaffected (Tailwind is externalized in `rollupOptions.external`)
- All 69 tests pass (68 existing + 1 new), linting clean, storybook builds
