### PR TITLE
fix(ez-card): #38 align card styles with M3 spec

### DIFF
--- a/packages/ui/scss/modules/card.scss
+++ b/packages/ui/scss/modules/card.scss
@@ -39,17 +39,39 @@ html[dir="rtl"] .ez-card:not(.ez-layout-vertical) {
 /* Filled */
 .ez-card.ez-filled {
   background: var(--md-sys-color-surface-container-highest, Canvas);
+  transition: box-shadow var(--md-sys-motion-duration-short2, 100ms) var(--md-sys-motion-easing-standard, ease);
+}
+
+.ez-card.ez-filled:is(a, button, [role="button"]):hover {
+  box-shadow: var(--md-sys-elevation-level1, 0 1px 2px 0 rgb(0 0 0 / 30%), 0 1px 3px 1px rgb(0 0 0 / 15%));
+}
+
+.ez-card.ez-filled:is(a, button, [role="button"]):active {
+  box-shadow: var(--md-sys-elevation-level0, none);
 }
 
 /* Outlined */
 .ez-card.ez-outlined {
   background: var(--md-sys-color-surface, Canvas);
   border: var(--ez-border-width, 1px) solid var(--md-sys-color-outline-variant, currentcolor);
+  transition: box-shadow var(--md-sys-motion-duration-short2, 100ms) var(--md-sys-motion-easing-standard, ease);
+}
+
+.ez-card.ez-outlined:is(a, button, [role="button"]):hover {
+  box-shadow: var(--md-sys-elevation-level1, 0 1px 2px 0 rgb(0 0 0 / 30%), 0 1px 3px 1px rgb(0 0 0 / 15%));
+}
+
+.ez-card.ez-outlined:is(a, button, [role="button"]):active {
+  box-shadow: var(--md-sys-elevation-level0, none);
+}
+
+.ez-card.ez-outlined:is(a, button, [role="button"]):focus-visible {
+  border-color: var(--md-sys-color-on-surface, CanvasText);
 }
 
 /* Focus indicator for interactive cards */
 .ez-card:is(a, button, [role="button"]):focus-visible {
-  outline: 3px solid var(--ez-focus-ring-color);
+  outline: 3px solid var(--md-sys-color-secondary, Highlight);
   outline-offset: 2px;
 }
 
@@ -71,9 +93,18 @@ html[dir="rtl"] .ez-card:not(.ez-layout-vertical) {
   }
 }
 
+.ez-card.ez-outlined:is([disabled], [aria-disabled="true"]) {
+  border-color: color-mix(in oklch, var(--md-sys-color-outline, currentcolor) 12%, transparent);
+}
+
 /* Dragged */
 .ez-card.ez-elevated.ez-dragged {
   box-shadow: var(--md-sys-elevation-level4, 0 2px 3px 0 rgb(0 0 0 / 30%), 0 6px 10px 4px rgb(0 0 0 / 15%));
+}
+
+.ez-card.ez-filled.ez-dragged,
+.ez-card.ez-outlined.ez-dragged {
+  box-shadow: var(--md-sys-elevation-level3, 0 1px 3px 0 rgb(0 0 0 / 30%), 0 4px 8px 3px rgb(0 0 0 / 15%));
 }
 
 /* Card sub-elements */


### PR DESCRIPTION
## Summary

Aligns `packages/ui/scss/modules/card.scss` with the M3 cards spec (`md/specs/m3-cards.specs.md`).

## Changes

- **Filled/outlined hover elevation** — added `level1` box-shadow on interactive card hover
- **Filled/outlined active elevation** — returns to `level0` on press
- **Filled/outlined dragged elevation** — added `level3`
- **Box-shadow transitions** — added to filled and outlined variants
- **Focus indicator color** — changed to `--md-sys-color-secondary` per spec (was `--ez-focus-ring-color`/primary)
- **Outlined disabled outline** — added `--md-sys-color-outline` at 12% opacity via `color-mix()`
- **Outlined focus border-color** — added `--md-sys-color-on-surface` on `:focus-visible`

Closes #38