### PR TITLE
refactor(ui): #41 replace custom SCSS plugin with Vite ?inline imports

### DIFF
--- a/packages/ui/ez-field/ez-field.style.ts
+++ b/packages/ui/ez-field/ez-field.style.ts
@@ -1,4 +1,4 @@
 import { unsafeCSS } from 'lit';
-import styles from './ez-field.scss';
+import styles from './ez-field.scss?inline';
 
 export default unsafeCSS(styles);

--- a/packages/ui/scss.d.ts
+++ b/packages/ui/scss.d.ts
@@ -2,3 +2,8 @@ declare module '*.scss' {
   const content: string;
   export default content;
 }
+
+declare module '*.scss?inline' {
+  const content: string;
+  export default content;
+}

--- a/packages/ui/vite.config.ts
+++ b/packages/ui/vite.config.ts
@@ -1,60 +1,19 @@
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { defineConfig, type Plugin } from 'vite';
+import { defineConfig } from 'vite';
 import tailwindcss from '@tailwindcss/vite';
 import react from '@vitejs/plugin-react';
 import storybookTest from '@storybook/addon-vitest/vitest-plugin';
 import { playwright } from '@vitest/browser-playwright';
-import * as sassCompiler from 'sass';
 
 import type { TestProjectInlineConfiguration } from 'vitest/config';
 
 const { NODE_ENV } = process.env,
   isDev = !NODE_ENV || NODE_ENV === 'development',
-  dirname = path.dirname(fileURLToPath(import.meta.url)),
-  COMPONENT_SCSS_PREFIX = '\0component-scss:';
-
-/**
- * Vite plugin that compiles component SCSS files to CSS strings for use
- * with Lit's unsafeCSS(). Uses virtual modules to avoid conflicts with
- * Vite's built-in CSS pipeline.
- *
- * Only handles SCSS imports from *.style.ts files. Global SCSS imports
- * (e.g., in preview.ts or story files) are unaffected.
- */
-function componentScssPlugin(): Plugin {
-  return {
-    name: 'component-scss',
-    enforce: 'pre',
-
-    resolveId(source, importer) {
-      if (!source.endsWith('.scss') || !importer) return null;
-      if (!source.startsWith('.') && !path.isAbsolute(source)) return null;
-
-      // Only handle SCSS imported from *.style.ts files
-      if (!importer.endsWith('.style.ts')) return null;
-
-      const resolved = path.resolve(path.dirname(importer), source);
-
-      // Strip .scss so Vite's CSS plugin doesn't match the virtual ID
-      return COMPONENT_SCSS_PREFIX + resolved.slice(0, -5);
-    },
-
-    load(id) {
-      if (!id.startsWith(COMPONENT_SCSS_PREFIX)) return null;
-
-      const filePath = id.slice(COMPONENT_SCSS_PREFIX.length) + '.scss',
-        result = sassCompiler.compile(filePath, {
-          loadPaths: [path.resolve(dirname, 'scss')],
-        });
-
-      return `export default ${JSON.stringify(result.css)};`;
-    },
-  };
-}
+  dirname = path.dirname(fileURLToPath(import.meta.url));
 
 export default defineConfig({
-  plugins: [tailwindcss(), componentScssPlugin(), react()],
+  plugins: [tailwindcss(), react()],
   resolve: {
     alias: {
       '@': dirname,


### PR DESCRIPTION
## Summary

Replaces the custom `componentScssPlugin()` in `packages/ui/vite.config.ts` with Vite's native [`?inline` CSS import syntax](https://vite.dev/guide/features#disabling-css-injection-into-the-page).

Closes #41

## Changes

| File | Change |
|------|--------|
| `packages/ui/vite.config.ts` | Removed `componentScssPlugin()` (~30 lines), `sass` import, and `COMPONENT_SCSS_PREFIX` constant |
| `packages/ui/ez-field/ez-field.style.ts` | `'./ez-field.scss'` → `'./ez-field.scss?inline'` |
| `packages/ui/scss.d.ts` | Added `*.scss?inline` type declaration |

## How it works

Vite natively supports the `?inline` query suffix on CSS/SCSS imports, which returns the compiled CSS as a string (default export) without injecting it into the page — the exact same behavior the custom plugin provided. This removes ~35 lines of plugin code with zero configuration needed.