### PR TITLE
feat(md-icon): #43 Default 24dp size and optical size variants

### DIFF
--- a/packages/ui/scss/material/symbol-icons-base.scss
+++ b/packages/ui/scss/material/symbol-icons-base.scss
@@ -7,15 +7,17 @@
 }
 
 .md-icon {
+  --_icon-size: 24px;
+
   font-family: 'Material Symbols Rounded', "Sans Serif Collection", sans-serif;
   font-weight: normal;
   font-style: normal;
-  font-size: var(--ez-16px);
+  font-size: var(--_icon-size);
   font-feature-settings: 'liga';
   font-variation-settings: 'FILL' 1,
   'wght' 400,
   'GRAD' 0,
-  'opsz' 48;
+  'opsz' 24;
   -webkit-font-smoothing: antialiased;
   line-height: 1;
   letter-spacing: normal;
@@ -23,6 +25,8 @@
   display: inline-block;
   white-space: nowrap;
   align-content: center;
+  width: var(--_icon-size);
+  height: var(--_icon-size);
 
   /* word-wrap: normal; */
   overflow-wrap: normal;
@@ -30,4 +34,29 @@
   padding: 0;
   pointer-events: none;
   user-select: none;
+}
+
+/*
+ * Optical size variants
+ * ------------------- */
+
+/* 20dp — desktop, dense layouts, small-scale visuals */
+:where(.md-icon).ez-small {
+  --_icon-size: 20px;
+
+  font-variation-settings: 'FILL' 1, 'wght' 400, 'GRAD' 0, 'opsz' 20;
+}
+
+/* 40dp — display or headline type, larger screens */
+:where(.md-icon).ez-large {
+  --_icon-size: 40px;
+
+  font-variation-settings: 'FILL' 1, 'wght' 400, 'GRAD' 0, 'opsz' 40;
+}
+
+/* 48dp — display contexts, largest screens */
+:where(.md-icon).ez-xlarge {
+  --_icon-size: 48px;
+
+  font-variation-settings: 'FILL' 1, 'wght' 400, 'GRAD' 0, 'opsz' 48;
 }


### PR DESCRIPTION
## Summary

Closes #43

Updates `.md-icon` to default to **24dp × 24dp** per M3 spec and adds optical size variants.

### Changes (`packages/ui/scss/material/symbol-icons-base.scss`)

- **Default** `.md-icon` → 24dp (was 16px), `opsz` → 24 (was 48), added `width`/`height` via `--_icon-size` custom property
- **`.ez-small`** → 20dp / opsz 20 — desktop, dense layouts, small-scale visuals
- **`.ez-large`** → 40dp / opsz 40 — display/headline type, larger screens
- **`.ez-xlarge`** → 48dp / opsz 48 — display contexts, largest screens

### Notes
- Parent component overrides (buttons, FABs, appbar) are unaffected — they already scope icon size via their own CSS custom properties.
- The `opsz` (optical size) axis now matches display size per variant for optimal Material Symbols rendering.