### PR TITLE
feat(ez-ripple): align state layer opacities with M3 spec

### DIFF
--- a/packages/ui/ez-ripple/ez-ripple.stories.ts
+++ b/packages/ui/ez-ripple/ez-ripple.stories.ts
@@ -113,3 +113,40 @@ export const RtlVariation: StoryObj = {
     await expect(ripple2).toHaveProperty('shadowRoot', null);
   },
 };
+
+export const DraggedStateVariation: StoryObj = {
+  render: () => html`
+    <p style="margin-bottom: 0.5rem;">
+      The dragged state uses a higher opacity (0.16) per M3 spec. The button
+      below has its parent marked as <code>.ez-dragged</code>.
+    </p>
+
+    <div class="ez-dragged" style="display: inline-block; position: relative;">
+      <button type="button" class="ez-btn ez-theme-primary">
+        <ez-ripple data-testid="ripple-dragged"></ez-ripple>
+        Dragged Button
+      </button>
+    </div>
+
+    <div style="display: inline-block; position: relative; margin-left: 1rem;">
+      <button type="button" class="ez-btn ez-theme-primary">
+        <ez-ripple dragged data-testid="ripple-dragged-attr"></ez-ripple>
+        Dragged (attr)
+      </button>
+    </div>
+  `,
+  play: async ({ canvas }) => {
+    const draggedBtn = canvas.getByTestId('ripple-dragged');
+
+    await expect(draggedBtn).toBeInTheDocument();
+    await expect(draggedBtn).toHaveProperty(
+      'nodeName',
+      EzRippleName.toUpperCase()
+    );
+
+    const draggedAttrBtn = canvas.getByTestId('ripple-dragged-attr');
+
+    await expect(draggedAttrBtn).toBeInTheDocument();
+    await expect(draggedAttrBtn).toHaveAttribute('dragged');
+  },
+};

--- a/packages/ui/ez-ripple/index.scss
+++ b/packages/ui/ez-ripple/index.scss
@@ -38,9 +38,16 @@
 ez-ripple {
   --ez-ripple-x: 50%;
   --ez-ripple-y: 50%;
-  --ez-ripple-opacity: 0.08;
+
+  /* M3 state-layer opacities (per-state) */
+  --ez-ripple-hover-opacity: var(--md-sys-state-hover-state-layer-opacity, 0.08);
+  --ez-ripple-focus-opacity: var(--md-sys-state-focus-state-layer-opacity, 0.1);
+  --ez-ripple-pressed-opacity: var(--md-sys-state-pressed-state-layer-opacity, 0.1);
+  --ez-ripple-dragged-opacity: var(--md-sys-state-dragged-state-layer-opacity, 0.16);
+
+  /* Ripple wave animation opacities */
   --ez-ripple-active-opacity: 0.16;
-  --ez-ripple-active-opacity-end: 0.1;
+  --ez-ripple-active-opacity-end: var(--ez-ripple-pressed-opacity);
   --ez-ripple-inactive-opacity: 0;
   --ez-ripple-active-scale: 1;
   --ez-ripple-inactive-scale: 0;
@@ -85,7 +92,7 @@ ez-ripple:not(:empty) > :first-child {
 }
 
 ez-ripple:not(:empty):hover {
-  background: oklch(from var(--md-color-on-theme) l c h / 10%);
+  background: oklch(from var(--md-color-on-theme) l c h / var(--ez-ripple-hover-opacity));
 }
 
 ez-ripple::after,
@@ -117,22 +124,63 @@ ez-ripple::before {
   z-index: 1;
 }
 
-ez-ripple:where(
-    [rippleactive]
-  )::before,
+/* Hover state layer */
 ez-ripple:has(
-    :hover,
-    :focus,
-    :active
+    :hover
   )::before,
-*:has(> ez-ripple:empty):where(:hover, :active, :focus) > ez-ripple:empty::before {
+*:has(> ez-ripple:empty):where(:hover) > ez-ripple:empty::before {
   transform: translate(
     var(--ez-ripple-x),
     var(--ez-ripple-y)
   ) scale(
     var(--ez-ripple-active-scale)
   );
-  opacity: var(--ez-ripple-opacity);
+  opacity: var(--ez-ripple-hover-opacity);
+}
+
+/* Focus state layer */
+ez-ripple:has(
+    :focus-visible
+  )::before,
+*:has(> ez-ripple:empty):where(:focus-visible) > ez-ripple:empty::before {
+  transform: translate(
+    var(--ez-ripple-x),
+    var(--ez-ripple-y)
+  ) scale(
+    var(--ez-ripple-active-scale)
+  );
+  opacity: var(--ez-ripple-focus-opacity);
+}
+
+/* Pressed state layer */
+ez-ripple:where(
+    [rippleactive]
+  )::before,
+ez-ripple:has(
+    :active
+  )::before,
+*:has(> ez-ripple:empty):where(:active) > ez-ripple:empty::before {
+  transform: translate(
+    var(--ez-ripple-x),
+    var(--ez-ripple-y)
+  ) scale(
+    var(--ez-ripple-active-scale)
+  );
+  opacity: var(--ez-ripple-pressed-opacity);
+}
+
+/* Dragged state layer */
+ez-ripple:where(
+    [dragged]
+  )::before,
+*:has(> ez-ripple:empty):where(.ez-dragged) > ez-ripple:empty::before {
+  transform: translate(
+    var(--ez-ripple-x),
+    var(--ez-ripple-y)
+  ) scale(
+    var(--ez-ripple-active-scale)
+  );
+  opacity: var(--ez-ripple-dragged-opacity);
 }
 
 ez-ripple::after {

--- a/packages/ui/scss/modules/button/filled.scss
+++ b/packages/ui/scss/modules/button/filled.scss
@@ -5,7 +5,6 @@
 /** Ripple styles **/
 :where(.ez-btn, .ez-button).ez-filled ez-ripple::after,
 :where(.ez-btn, .ez-button).ez-filled ez-ripple::before {
-  --ez-ripple-hover-opacity: 0.55;
   --ez-ripple-active-opacity: 0.21;
 
   background: var(--md-color-on-theme);


### PR DESCRIPTION
## Summary

Aligns ez-ripple state layer opacities with Material Design 3 spec values by introducing per-state CSS custom properties.

### Problem

The component used a single `--ez-ripple-opacity: 0.08` for all interactive states (hover, focus, active). M3 requires distinct opacities:

| State | M3 Spec | Before | After |
|---|---|---|---|
| Hover | 0.08 | ✅ 0.08 | ✅ 0.08 |
| Focus | 0.1 | ❌ 0.08 | ✅ 0.1 |
| Pressed | 0.1 | ❌ 0.08 | ✅ 0.1 |
| Dragged | 0.16 | ❌ None | ✅ 0.16 |

### Changes

- **Per-state opacity properties** linked to `--md-sys-state-*` tokens:
  - `--ez-ripple-hover-opacity`, `--ez-ripple-focus-opacity`, `--ez-ripple-pressed-opacity`, `--ez-ripple-dragged-opacity`
- **Split `::before` selectors** by state (`:hover`, `:focus-visible`, `:active`, `[dragged]`/`.ez-dragged`)
- **Dragged state support** via `[dragged]` attribute or `.ez-dragged` parent class
- **Fixed non-empty hover** from hardcoded `10%` to token-based value
- **Removed dead** `--ez-ripple-hover-opacity: 0.55` from `filled.scss`
- **Added** `DraggedStateVariation` storybook story

### Files Changed

- `packages/ui/ez-ripple/index.scss` — Core refactor
- `packages/ui/ez-ripple/ez-ripple.stories.ts` — New dragged state story
- `packages/ui/scss/modules/button/filled.scss` — Cleanup dead property
