### PR TITLE
feat(ez-button-group): #48 add .ez-btn-group alias and layout classes

### DIFF
--- a/packages/ui/ez-button-group/index.stories.ts
+++ b/packages/ui/ez-button-group/index.stories.ts
@@ -1,4 +1,5 @@
 import { html } from 'lit';
+import { expect } from 'storybook/test';
 import type { StoryObj } from '@storybook/web-components-vite';
 import { EzThemeVariants, EzSizeVariants } from '../utils/constants.js';
 import '../ez-ripple';
@@ -445,4 +446,119 @@ export const CheckboxControlGroup: StoryObj = {
       </div>
     </section>
   `,
+};
+
+/**
+ * Vertical (block) layout — buttons stacked in a column using `.ez-layout-block`.
+ */
+export const VerticalLayout: StoryObj = {
+  render: () => html`
+    <section>
+      <header>
+        <h2>Vertical Layout (<code>.ez-layout-block</code>)</h2>
+      </header>
+
+      <div
+        class="ez-section-body"
+        style="display:flex;gap:2rem;flex-wrap:wrap;align-items:start;"
+      >
+        <div>
+          <h3>Default (spaced)</h3>
+          <div
+            class="ez-button-group ez-layout-block"
+            data-testid="vertical-default"
+          >
+            ${['Top', 'Middle', 'Bottom'].map(
+              label => html`
+                <button class="ez-btn ez-filled ez-theme-primary" type="button">
+                  <ez-ripple></ez-ripple>
+                  <span>${label}</span>
+                </button>
+              `
+            )}
+          </div>
+        </div>
+
+        <div>
+          <h3>Connected</h3>
+          <div
+            class="ez-button-group ez-layout-block ez-connected"
+            data-testid="vertical-connected"
+          >
+            ${['Top', 'Middle', 'Bottom'].map(
+              label => html`
+                <button
+                  class="ez-btn ez-outlined ez-theme-secondary"
+                  type="button"
+                >
+                  <ez-ripple></ez-ripple>
+                  <span>${label}</span>
+                </button>
+              `
+            )}
+          </div>
+        </div>
+
+        <div>
+          <h3>Connected Radio</h3>
+          <div
+            class="ez-button-group ez-layout-block ez-connected"
+            data-testid="vertical-radio"
+          >
+            ${['Option A', 'Option B', 'Option C'].map(
+              (label, i) => html`
+                <label
+                  class="ez-btn ez-filled ez-theme-primary"
+                  for="vert-radio-${i}"
+                >
+                  <input
+                    type="radio"
+                    name="vert-radio"
+                    id="vert-radio-${i}"
+                    value="${label}"
+                    ?checked=${i === 0}
+                  />
+                  <ez-ripple></ez-ripple>
+                  <span>${label}</span>
+                </label>
+              `
+            )}
+          </div>
+        </div>
+      </div>
+    </section>
+  `,
+
+  play: async ({ canvasElement }) => {
+    const defaultGroup = canvasElement.querySelector(
+        '[data-testid="vertical-default"]'
+      ),
+      connectedGroup = canvasElement.querySelector(
+        '[data-testid="vertical-connected"]'
+      ),
+      radioGroup = canvasElement.querySelector(
+        '[data-testid="vertical-radio"]'
+      );
+
+    if (!defaultGroup || !connectedGroup || !radioGroup) return;
+
+    // Verify groups exist and have correct layout class
+    await expect(defaultGroup).toBeInTheDocument();
+    await expect(defaultGroup).toHaveClass('ez-layout-block');
+
+    await expect(connectedGroup).toBeInTheDocument();
+    await expect(connectedGroup).toHaveClass('ez-layout-block');
+    await expect(connectedGroup).toHaveClass('ez-connected');
+
+    // Verify flex-direction is column
+    await expect(getComputedStyle(defaultGroup).flexDirection).toBe('column');
+    await expect(getComputedStyle(connectedGroup).flexDirection).toBe('column');
+
+    // Verify radio group renders with vertical layout
+    await expect(radioGroup).toBeInTheDocument();
+    await expect(
+      radioGroup.querySelectorAll('input[type="radio"]').length
+    ).toBe(3);
+    await expect(getComputedStyle(radioGroup).flexDirection).toBe('column');
+  },
 };

--- a/packages/ui/scss/modules/button/button-group.scss
+++ b/packages/ui/scss/modules/button/button-group.scss
@@ -1,7 +1,7 @@
 /**
  * .ez-button-group
  * ---------------- */
-.ez-button-group {
+:where(.ez-button-group, .ez-btn-group) {
   --_btn-group-gap: 12px;
 
   display: inline-flex;
@@ -11,24 +11,35 @@
 }
 
 /**
+ * Layout direction
+ * -------------------- */
+:where(.ez-button-group, .ez-btn-group).ez-layout-block {
+  flex-direction: column;
+}
+
+:where(.ez-button-group, .ez-btn-group).ez-layout-inline {
+  flex-direction: row;
+}
+
+/**
  * Standard variant — size-aware gaps
  * -------------------- */
-:where(.ez-button-group):is(.ez-xsmall) {
+:where(.ez-button-group, .ez-btn-group):is(.ez-xsmall) {
   --_btn-group-gap: 18px;
 }
 
-.ez-button-group:is(.ez-small) {
+:where(.ez-button-group, .ez-btn-group):is(.ez-small) {
   --_btn-group-gap: 12px;
 }
 
-:where(.ez-button-group):is(.ez-medium, .ez-large, .ez-xlarge) {
+:where(.ez-button-group, .ez-btn-group):is(.ez-medium, .ez-large, .ez-xlarge) {
   --_btn-group-gap: 8px;
 }
 
 /**
  * Connected variant
  * -------------------- */
-:where(.ez-button-group):is(.ez-connected, [connected]) {
+:where(.ez-button-group, .ez-btn-group):is(.ez-connected, [connected]) {
   --_btn-group-gap: 2px;
   --_connected-inner-corner: 8px;
 
@@ -36,12 +47,12 @@
 }
 
 /* Middle children — all corners inner */
-:where(.ez-button-group):is(.ez-connected, [connected]) > :where(.ez-btn, .ez-button):not(:first-child, :last-child) {
+:where(.ez-button-group, .ez-btn-group):is(.ez-connected, [connected]) > :where(.ez-btn, .ez-button):not(:first-child, :last-child) {
   border-radius: var(--_connected-inner-corner);
 }
 
 /* First child — outer-start rounded, inner-end = inner corner */
-:where(.ez-button-group):is(.ez-connected, [connected]) > :where(.ez-btn, .ez-button):first-child {
+:where(.ez-button-group, .ez-btn-group):is(.ez-connected, [connected]) > :where(.ez-btn, .ez-button):first-child {
   border-start-start-radius: var(--_btn-container-shape);
   border-end-start-radius: var(--_btn-container-shape);
   border-start-end-radius: var(--_connected-inner-corner);
@@ -49,7 +60,7 @@
 }
 
 /* Last child — outer-end rounded, inner-start = inner corner */
-:where(.ez-button-group):is(.ez-connected, [connected]) > :where(.ez-btn, .ez-button):last-child {
+:where(.ez-button-group, .ez-btn-group):is(.ez-connected, [connected]) > :where(.ez-btn, .ez-button):last-child {
   border-start-end-radius: var(--_btn-container-shape);
   border-end-end-radius: var(--_btn-container-shape);
   border-start-start-radius: var(--_connected-inner-corner);
@@ -57,55 +68,84 @@
 }
 
 /* Solo child — fully rounded */
-:where(.ez-button-group):is(.ez-connected, [connected]) > :where(.ez-btn, .ez-button):only-child {
+:where(.ez-button-group, .ez-btn-group):is(.ez-connected, [connected]) > :where(.ez-btn, .ez-button):only-child {
   border-radius: var(--_btn-container-shape);
 }
 
+/* Block (vertical) connected — override inline-direction corners for block-direction */
+:where(.ez-button-group, .ez-btn-group):is(.ez-connected, [connected]).ez-layout-block > :where(.ez-btn, .ez-button):first-child {
+  border-start-start-radius: var(--_btn-container-shape);
+  border-start-end-radius: var(--_btn-container-shape);
+  border-end-start-radius: var(--_connected-inner-corner);
+  border-end-end-radius: var(--_connected-inner-corner);
+}
+
+:where(.ez-button-group, .ez-btn-group):is(.ez-connected, [connected]).ez-layout-block > :where(.ez-btn, .ez-button):last-child {
+  border-end-start-radius: var(--_btn-container-shape);
+  border-end-end-radius: var(--_btn-container-shape);
+  border-start-start-radius: var(--_connected-inner-corner);
+  border-start-end-radius: var(--_connected-inner-corner);
+}
+
+/* Block connected — first child state corner on block-end */
+:where(.ez-button-group, .ez-btn-group):is(.ez-connected, [connected]).ez-layout-block > :where(.ez-btn, .ez-button):is(:not(:disabled):active, [aria-pressed="true"], .ez-selected, :has(input:checked)):first-child {
+  border-start-end-radius: var(--_btn-container-shape);
+  border-end-start-radius: var(--_connected-state-corner);
+  border-end-end-radius: var(--_connected-state-corner);
+}
+
+/* Block connected — last child state corner on block-start */
+:where(.ez-button-group, .ez-btn-group):is(.ez-connected, [connected]).ez-layout-block > :where(.ez-btn, .ez-button):is(:not(:disabled):active, [aria-pressed="true"], .ez-selected, :has(input:checked)):last-child {
+  border-end-start-radius: var(--_btn-container-shape);
+  border-start-start-radius: var(--_connected-state-corner);
+  border-start-end-radius: var(--_connected-state-corner);
+}
+
 /* Connected size overrides — inner corner */
-:where(.ez-button-group):is(.ez-connected, [connected]).ez-large {
+:where(.ez-button-group, .ez-btn-group):is(.ez-connected, [connected]).ez-large {
   --_connected-inner-corner: 16px;
 }
 
-:where(.ez-button-group):is(.ez-connected, [connected]).ez-xlarge {
+:where(.ez-button-group, .ez-btn-group):is(.ez-connected, [connected]).ez-xlarge {
   --_connected-inner-corner: 20px;
 }
 
 /* Connected state corner — variable set per state/size, structural rules applied once */
-:where(.ez-button-group):is(.ez-connected, [connected]) > :where(.ez-btn, .ez-button):not(:disabled):active {
+:where(.ez-button-group, .ez-btn-group):is(.ez-connected, [connected]) > :where(.ez-btn, .ez-button):not(:disabled):active {
   --_connected-state-corner: 4px;
 }
 
-:where(.ez-button-group):is(.ez-connected, [connected]).ez-large > :where(.ez-btn, .ez-button):not(:disabled):active {
+:where(.ez-button-group, .ez-btn-group):is(.ez-connected, [connected]).ez-large > :where(.ez-btn, .ez-button):not(:disabled):active {
   --_connected-state-corner: 12px;
 }
 
-:where(.ez-button-group):is(.ez-connected, [connected]).ez-xlarge > :where(.ez-btn, .ez-button):not(:disabled):active {
+:where(.ez-button-group, .ez-btn-group):is(.ez-connected, [connected]).ez-xlarge > :where(.ez-btn, .ez-button):not(:disabled):active {
   --_connected-state-corner: 16px;
 }
 
-:where(.ez-button-group):is(.ez-connected, [connected]) > :where(.ez-btn, .ez-button):is([aria-pressed="true"], .ez-selected, :has(input:checked)) {
+:where(.ez-button-group, .ez-btn-group):is(.ez-connected, [connected]) > :where(.ez-btn, .ez-button):is([aria-pressed="true"], .ez-selected, :has(input:checked)) {
   --_connected-state-corner: calc(var(--_btn-container-height) / 2);
 }
 
 /* Middle children — state corner */
-:where(.ez-button-group):is(.ez-connected, [connected]) > :where(.ez-btn, .ez-button):is(:not(:disabled):active, [aria-pressed="true"], .ez-selected, :has(input:checked)):not(:first-child, :last-child) {
+:where(.ez-button-group, .ez-btn-group):is(.ez-connected, [connected]) > :where(.ez-btn, .ez-button):is(:not(:disabled):active, [aria-pressed="true"], .ez-selected, :has(input:checked)):not(:first-child, :last-child) {
   border-radius: var(--_connected-state-corner);
 }
 
 /* First child — preserve outer-start, state corner on inner-end */
-:where(.ez-button-group):is(.ez-connected, [connected]) > :where(.ez-btn, .ez-button):is(:not(:disabled):active, [aria-pressed="true"], .ez-selected, :has(input:checked)):first-child {
+:where(.ez-button-group, .ez-btn-group):is(.ez-connected, [connected]) > :where(.ez-btn, .ez-button):is(:not(:disabled):active, [aria-pressed="true"], .ez-selected, :has(input:checked)):first-child {
   border-start-end-radius: var(--_connected-state-corner);
   border-end-end-radius: var(--_connected-state-corner);
 }
 
 /* Last child — preserve outer-end, state corner on inner-start */
-:where(.ez-button-group):is(.ez-connected, [connected]) > :where(.ez-btn, .ez-button):is(:not(:disabled):active, [aria-pressed="true"], .ez-selected, :has(input:checked)):last-child {
+:where(.ez-button-group, .ez-btn-group):is(.ez-connected, [connected]) > :where(.ez-btn, .ez-button):is(:not(:disabled):active, [aria-pressed="true"], .ez-selected, :has(input:checked)):last-child {
   border-start-start-radius: var(--_connected-state-corner);
   border-end-start-radius: var(--_connected-state-corner);
 }
 
 /* Disable shape-morph animations inside connected groups */
-:where(.ez-button-group):is(.ez-connected, [connected]) > :where(.ez-btn, .ez-button) {
+:where(.ez-button-group, .ez-btn-group):is(.ez-connected, [connected]) > :where(.ez-btn, .ez-button) {
   animation: none;
 }
 
@@ -116,19 +156,19 @@
 /* Active/selected button expands */
 
 /*
-:where(.ez-button-group) > :where(.ez-btn, .ez-button):is(:not(:disabled):active, [aria-pressed="true"], .ez-selected, :has(input:checked)) {
+:where(.ez-button-group, .ez-btn-group) > :where(.ez-btn, .ez-button):is(:not(:disabled):active, [aria-pressed="true"], .ez-selected, :has(input:checked)) {
   --_btn-scale: 1.08;
   --_btn-inv-x: 0.926;
 }
 
 !* Immediate next sibling contracts *!
-:where(.ez-button-group) > :where(.ez-btn, .ez-button):is(:not(:disabled):active, [aria-pressed="true"], .ez-selected, :has(input:checked)) + :where(.ez-btn, .ez-button):not(:is([aria-pressed="true"], .ez-selected, :has(input:checked))) {
+:where(.ez-button-group, .ez-btn-group) > :where(.ez-btn, .ez-button):is(:not(:disabled):active, [aria-pressed="true"], .ez-selected, :has(input:checked)) + :where(.ez-btn, .ez-button):not(:is([aria-pressed="true"], .ez-selected, :has(input:checked))) {
   --_btn-scale: 0.94;
   --_btn-inv-x: 1.064;
 }
 
 !* Immediate previous sibling contracts *!
-:where(.ez-button-group) > :where(.ez-btn, .ez-button):not(:is([aria-pressed="true"], .ez-selected, :has(input:checked))):has(+ :where(.ez-btn, .ez-button):is(:not(:disabled):active, [aria-pressed="true"], .ez-selected, :has(input:checked))) {
+:where(.ez-button-group, .ez-btn-group) > :where(.ez-btn, .ez-button):not(:is([aria-pressed="true"], .ez-selected, :has(input:checked))):has(+ :where(.ez-btn, .ez-button):is(:not(:disabled):active, [aria-pressed="true"], .ez-selected, :has(input:checked))) {
   --_btn-scale: 0.94;
   --_btn-inv-x: 1.064;
 }
@@ -139,20 +179,20 @@
  * -------------------- */
 
 /* Shape morph: pill → squarish when selected */
-:where(.ez-button-group) > :where(.ez-btn, .ez-button):not(:disabled):is([aria-pressed="true"], .ez-selected, :has(input:checked)) {
+:where(.ez-button-group, .ez-btn-group) > :where(.ez-btn, .ez-button):not(:disabled):is([aria-pressed="true"], .ez-selected, :has(input:checked)) {
   animation: ez-btn-selected-morph 300ms cubic-bezier(0.38, 1.21, 0.22, 1.00) forwards;
 }
 
-:where(.ez-button-group) > :where(.ez-btn, .ez-button):not(:disabled):is([aria-pressed="true"], .ez-selected, :has(input:checked)):is(.ez-util, .ez-xsmall, .ez-small) {
+:where(.ez-button-group, .ez-btn-group) > :where(.ez-btn, .ez-button):not(:disabled):is([aria-pressed="true"], .ez-selected, :has(input:checked)):is(.ez-util, .ez-xsmall, .ez-small) {
   --_btn-selected-shape: 12px;
 }
 
-:where(.ez-button-group) > :where(.ez-btn, .ez-button):not(:disabled):is([aria-pressed="true"], .ez-selected, :has(input:checked)):is(.ez-large, .ez-xlarge) {
+:where(.ez-button-group, .ez-btn-group) > :where(.ez-btn, .ez-button):not(:disabled):is([aria-pressed="true"], .ez-selected, :has(input:checked)):is(.ez-large, .ez-xlarge) {
   --_btn-selected-shape: 28px;
 }
 
 /* Square buttons → circular when selected */
-:where(.ez-button-group) > :where(.ez-btn, .ez-button).ez-square:is([aria-pressed="true"], .ez-selected, :has(input:checked)) {
+:where(.ez-button-group, .ez-btn-group) > :where(.ez-btn, .ez-button).ez-square:is([aria-pressed="true"], .ez-selected, :has(input:checked)) {
   --_btn-selected-shape: calc(var(--_btn-container-height) / 2);
 }
 
@@ -160,7 +200,7 @@
  ------------------------ **/
 
 /* Color: filled not-selected state */
-.ez-button-group:has(input[type]) > :where(.ez-btn, .ez-button).ez-filled:not([aria-pressed="true"], .ez-selected, :has(input:checked)) {
+:where(.ez-button-group, .ez-btn-group):has(input[type]) > :where(.ez-btn, .ez-button).ez-filled:not([aria-pressed="true"], .ez-selected, :has(input:checked)) {
   background-color: oklch(from var(--md-color-on-theme) calc(l - 0.1) c h);
   color: var(--md-color-theme);
 
@@ -171,7 +211,7 @@
 }
 
 /* Color: filled selected state */
-.ez-button-group:has(input[type]) > :where(.ez-btn, .ez-button).ez-filled:is([aria-pressed="true"], .ez-selected, :has(input:checked)) {
+:where(.ez-button-group, .ez-btn-group):has(input[type]) > :where(.ez-btn, .ez-button).ez-filled:is([aria-pressed="true"], .ez-selected, :has(input:checked)) {
   background-color: oklch(from var(--md-color-theme) calc(l - 0.1) c h);
   color: var(--md-color-on-theme);
 
@@ -197,7 +237,7 @@
 /* } */
 
 /* Color: non-filled (text, outlined, elevated, tonal) selected state */
-.ez-button-group:has(input[type]) > :where(.ez-btn, .ez-button):not(.ez-filled):is([aria-pressed="true"], .ez-selected, :has(input:checked)) {
+:where(.ez-button-group, .ez-btn-group):has(input[type]) > :where(.ez-btn, .ez-button):not(.ez-filled):is([aria-pressed="true"], .ez-selected, :has(input:checked)) {
   background-color: oklch(from var(--md-color-theme) l c h);
   color: var(--md-color-on-theme);
 }
@@ -206,7 +246,7 @@
  -------------------------- */
 
 /* Color: outlined selected state — update border */
-.ez-button-group:has(input[type]) > :where(.ez-btn, .ez-button).ez-outlined:is([aria-pressed="true"], .ez-selected, :has(input:checked)) {
+:where(.ez-button-group, .ez-btn-group):has(input[type]) > :where(.ez-btn, .ez-button).ez-outlined:is([aria-pressed="true"], .ez-selected, :has(input:checked)) {
   border-color: oklch(from var(--md-color-theme) calc(l - 0.13) c h);
 }
 


### PR DESCRIPTION
## Changes

- Add `.ez-btn-group` as alias for `.ez-button-group` via `:where()` selectors throughout `button-group.scss`
- Add `.ez-layout-block` / `.ez-layout-inline` classes for vertical/horizontal layout direction
- Add block-direction connected border-radius overrides for vertical connected groups
- Add `VerticalLayout` storybook story with play function assertions

Closes #48