### PR TITLE
feat(ez-card): #65 Update card classes and stories

### DIFF
--- a/packages/ui/ez-card/index.stories.ts
+++ b/packages/ui/ez-card/index.stories.ts
@@ -1,11 +1,15 @@
 import { html } from 'lit';
+import { expect } from 'storybook/test';
+import type { StoryObj } from '@storybook/web-components-vite';
 import './../ez-ripple';
 
 export default {
   title: 'CSS Components/Card',
 };
 
-export const Variants = {
+type Story = StoryObj;
+
+export const Variants: Story = {
   render: () => html`
     <section dir="ltr">
       <header><h2>Card Variants</h2></header>
@@ -16,15 +20,15 @@ export const Variants = {
       >
         <div class="ez-card ez-elevated">
           <div class="ez-card__header">
-            <h3 style="margin: 0;">Elevated Card</h3>
-            <p style="margin: 0; opacity: 0.7;">Subtitle</p>
+            <h3 class="ez-card__title">Elevated Card</h3>
+            <p class="ez-card__subtitle">Subtitle</p>
           </div>
-          <div class="ez-card__content">
-            <p style="margin: 0;">
+          <div class="ez-card__body">
+            <p>
               Elevated cards have a shadow and surface-container-low background.
             </p>
           </div>
-          <div class="ez-card__actions">
+          <div class="ez-card__footer">
             <button class="ez-btn ez-text" type="button">
               <ez-ripple></ez-ripple>
               Action
@@ -34,16 +38,16 @@ export const Variants = {
 
         <div class="ez-card ez-filled">
           <div class="ez-card__header">
-            <h3 style="margin: 0;">Filled Card</h3>
-            <p style="margin: 0; opacity: 0.7;">Subtitle</p>
+            <h3 class="ez-card__title">Filled Card</h3>
+            <p class="ez-card__subtitle">Subtitle</p>
           </div>
-          <div class="ez-card__content">
-            <p style="margin: 0;">
+          <div class="ez-card__body">
+            <p>
               Filled cards use surface-container-highest background with no
               shadow.
             </p>
           </div>
-          <div class="ez-card__actions">
+          <div class="ez-card__footer">
             <button class="ez-btn ez-text" type="button">
               <ez-ripple></ez-ripple>
               Action
@@ -53,15 +57,13 @@ export const Variants = {
 
         <div class="ez-card ez-outlined">
           <div class="ez-card__header">
-            <h3 style="margin: 0;">Outlined Card</h3>
-            <p style="margin: 0; opacity: 0.7;">Subtitle</p>
+            <h3 class="ez-card__title">Outlined Card</h3>
+            <p class="ez-card__subtitle">Subtitle</p>
           </div>
-          <div class="ez-card__content">
-            <p style="margin: 0;">
-              Outlined cards have a border and surface background.
-            </p>
+          <div class="ez-card__body">
+            <p>Outlined cards have a border and surface background.</p>
           </div>
-          <div class="ez-card__actions">
+          <div class="ez-card__footer">
             <button class="ez-btn" type="button">
               <ez-ripple></ez-ripple>
               Action 1
@@ -75,9 +77,28 @@ export const Variants = {
       </div>
     </section>
   `,
+  play: async ({ canvasElement }) => {
+    const cards = canvasElement.querySelectorAll('.ez-card');
+
+    await expect(cards.length).toBe(3);
+
+    await Promise.all(
+      Array.from(cards).map(async card => {
+        const title = card.querySelector('.ez-card__title'),
+          subtitle = card.querySelector('.ez-card__subtitle'),
+          body = card.querySelector('.ez-card__body'),
+          footer = card.querySelector('.ez-card__footer');
+
+        await expect(title).toBeTruthy();
+        await expect(subtitle).toBeTruthy();
+        await expect(body).toBeTruthy();
+        await expect(footer).toBeTruthy();
+      })
+    );
+  },
 };
 
-export const WithMedia = {
+export const WithMedia: Story = {
   render: () => html`
     <section>
       <header><h2>Card with Media</h2></header>
@@ -87,18 +108,17 @@ export const WithMedia = {
         style="display: flex; gap: 1rem; flex-wrap: wrap;"
       >
         <div class="ez-card ez-elevated" style="width: 320px;">
-          <div class="ez-card__media">
-            <div
-              style="height: 180px; background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);"
-            ></div>
-          </div>
+          <div
+            class="ez-card__media"
+            style="height: 180px; background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);"
+          ></div>
           <div class="ez-card__header">
-            <h3 style="margin: 0;">Media Card</h3>
+            <h3 class="ez-card__title">Media Card</h3>
           </div>
-          <div class="ez-card__content">
-            <p style="margin: 0;">Card with a media area at the top.</p>
+          <div class="ez-card__body">
+            <p>Card with a media area at the top.</p>
           </div>
-          <div class="ez-card__actions">
+          <div class="ez-card__footer">
             <button class="ez-btn ez-text" type="button">
               <ez-ripple></ez-ripple>
               Share
@@ -112,13 +132,19 @@ export const WithMedia = {
       </div>
     </section>
   `,
+  play: async ({ canvasElement }) => {
+    const media = canvasElement.querySelector('.ez-card__media');
+
+    await expect(media).toBeTruthy();
+    await expect(media ? getComputedStyle(media).display : '').toBe('block');
+  },
 };
 
-export const Disabled = {
+export const Disabled: Story = {
   render: () => html`
     <section>
       <header><h2>Disabled Cards</h2></header>
-      <p style="margin: 0 0 1rem; opacity: 0.7;">
+      <p class="ez-card__subtitle">
         Disabled cards have reduced opacity and no pointer interaction.
       </p>
 
@@ -128,12 +154,12 @@ export const Disabled = {
       >
         <div class="ez-card ez-elevated" disabled>
           <div class="ez-card__header">
-            <h3 style="margin: 0;">Elevated (disabled)</h3>
+            <h3 class="ez-card__title">Elevated (disabled)</h3>
           </div>
-          <div class="ez-card__content">
-            <p style="margin: 0;">Uses the <code>disabled</code> attribute.</p>
+          <div class="ez-card__body">
+            <p>Uses the <code>disabled</code> attribute.</p>
           </div>
-          <div class="ez-card__actions">
+          <div class="ez-card__footer">
             <button class="ez-btn ez-text" type="button">
               <ez-ripple></ez-ripple>
               Action
@@ -143,12 +169,12 @@ export const Disabled = {
 
         <div class="ez-card ez-filled" aria-disabled="true">
           <div class="ez-card__header">
-            <h3 style="margin: 0;">Filled (aria-disabled)</h3>
+            <h3 class="ez-card__title">Filled (aria-disabled)</h3>
           </div>
-          <div class="ez-card__content">
-            <p style="margin: 0;">Uses <code>aria-disabled="true"</code>.</p>
+          <div class="ez-card__body">
+            <p>Uses <code>aria-disabled="true"</code>.</p>
           </div>
-          <div class="ez-card__actions">
+          <div class="ez-card__footer">
             <button class="ez-btn ez-text" type="button">
               <ez-ripple></ez-ripple>Action
             </button>
@@ -157,12 +183,12 @@ export const Disabled = {
 
         <div class="ez-card ez-outlined" disabled>
           <div class="ez-card__header">
-            <h3 style="margin: 0;">Outlined (disabled)</h3>
+            <h3 class="ez-card__title">Outlined (disabled)</h3>
           </div>
-          <div class="ez-card__content">
-            <p style="margin: 0;">Uses the <code>disabled</code> attribute.</p>
+          <div class="ez-card__body">
+            <p>Uses the <code>disabled</code> attribute.</p>
           </div>
-          <div class="ez-card__actions">
+          <div class="ez-card__footer">
             <button class="ez-btn ez-outlined" type="button">
               <ez-ripple></ez-ripple>Action
             </button>
@@ -171,13 +197,28 @@ export const Disabled = {
       </div>
     </section>
   `,
+  play: async ({ canvasElement }) => {
+    const disabledCards = canvasElement.querySelectorAll(
+      '.ez-card[disabled], .ez-card[aria-disabled="true"]'
+    );
+
+    await expect(disabledCards.length).toBe(3);
+
+    await Promise.all(
+      Array.from(disabledCards).map(async card => {
+        const opacity = parseFloat(getComputedStyle(card).opacity);
+
+        await expect(opacity).toBeLessThan(1);
+      })
+    );
+  },
 };
 
-export const InteractiveCards = {
+export const InteractiveCards: Story = {
   render: () => html`
     <section>
       <header><h2>Interactive Cards</h2></header>
-      <p style="margin: 0 0 1rem; opacity: 0.7;">
+      <p class="ez-card__subtitle">
         Cards rendered as links, buttons, or with <code>role="button"</code>
         gain a focus-visible ring. Tab through to see the focus indicator.
       </p>
@@ -192,15 +233,11 @@ export const InteractiveCards = {
         >
           <ez-ripple></ez-ripple>
           <div class="ez-card__header">
-            <h3 style="margin: 0;">Link Card</h3>
-            <p style="margin: 0; opacity: 0.7;">
-              Rendered as <code>&lt;a&gt;</code>
-            </p>
+            <h3 class="ez-card__title">Link Card</h3>
+            <p class="ez-card__subtitle">Rendered as <code>&lt;a&gt;</code></p>
           </div>
-          <div class="ez-card__content">
-            <p style="margin: 0;">
-              Click or tab to this card. It navigates like a link.
-            </p>
+          <div class="ez-card__body">
+            <p>Click or tab to this card. It navigates like a link.</p>
           </div>
         </a>
 
@@ -211,28 +248,24 @@ export const InteractiveCards = {
         >
           <ez-ripple></ez-ripple>
           <div class="ez-card__header">
-            <h3 style="margin: 0;">Button Card</h3>
-            <p style="margin: 0; opacity: 0.7;">
+            <h3 class="ez-card__title">Button Card</h3>
+            <p class="ez-card__subtitle">
               Rendered as <code>&lt;button&gt;</code>
             </p>
           </div>
-          <div class="ez-card__content">
-            <p style="margin: 0;">
-              Click or tab to this card. It acts as a button.
-            </p>
+          <div class="ez-card__body">
+            <p>Click or tab to this card. It acts as a button.</p>
           </div>
         </button>
 
         <div class="ez-card ez-outlined" role="button" tabindex="0">
           <ez-ripple></ez-ripple>
           <div class="ez-card__header">
-            <h3 style="margin: 0;">Role Button Card</h3>
-            <p style="margin: 0; opacity: 0.7;">
-              Uses <code>role="button"</code>
-            </p>
+            <h3 class="ez-card__title">Role Button Card</h3>
+            <p class="ez-card__subtitle">Uses <code>role="button"</code></p>
           </div>
-          <div class="ez-card__content">
-            <p style="margin: 0;">
+          <div class="ez-card__body">
+            <p>
               Focusable via <code>tabindex="0"</code> with focus-visible ring.
             </p>
           </div>
@@ -240,13 +273,20 @@ export const InteractiveCards = {
       </div>
     </section>
   `,
+  play: async ({ canvasElement }) => {
+    const interactiveCards = canvasElement.querySelectorAll(
+      'a.ez-card, button.ez-card, .ez-card[role="button"]'
+    );
+
+    await expect(interactiveCards.length).toBe(3);
+  },
 };
 
-export const Dragged = {
+export const Dragged: Story = {
   render: () => html`
     <section>
       <header><h2>Dragged State</h2></header>
-      <p style="margin: 0 0 1rem; opacity: 0.7;">
+      <p class="ez-card__subtitle">
         Elevated cards gain a deeper shadow (level 4) when the
         <code>ez-dragged</code> class is applied.
       </p>
@@ -256,38 +296,52 @@ export const Dragged = {
         style="display: flex; gap: 2rem; flex-wrap: wrap; align-items: start;"
       >
         <div>
-          <p style="margin: 0 0 0.5rem;"><strong>Normal</strong></p>
+          <p><strong>Normal</strong></p>
           <div class="ez-card ez-elevated">
             <div class="ez-card__header">
-              <h3 style="margin: 0;">Elevated Card</h3>
+              <h3 class="ez-card__title">Elevated Card</h3>
             </div>
-            <div class="ez-card__content">
-              <p style="margin: 0;">Default elevation (level 1).</p>
+            <div class="ez-card__body">
+              <p>Default elevation (level 1).</p>
             </div>
           </div>
         </div>
 
         <div>
-          <p style="margin: 0 0 0.5rem;"><strong>Dragged</strong></p>
+          <p><strong>Dragged</strong></p>
           <div class="ez-card ez-elevated ez-dragged">
             <div class="ez-card__header">
-              <h3 style="margin: 0;">Dragged Card</h3>
+              <h3 class="ez-card__title">Dragged Card</h3>
             </div>
-            <div class="ez-card__content">
-              <p style="margin: 0;">Dragged elevation (level 4).</p>
+            <div class="ez-card__body">
+              <p>Dragged elevation (level 4).</p>
             </div>
           </div>
         </div>
       </div>
     </section>
   `,
+  play: async ({ canvasElement }) => {
+    const draggedCard = canvasElement.querySelector('.ez-card.ez-dragged'),
+      normalCard = canvasElement.querySelector('.ez-card:not(.ez-dragged)');
+
+    await expect(draggedCard).toBeTruthy();
+    await expect(normalCard).toBeTruthy();
+
+    const draggedShadow = draggedCard
+        ? getComputedStyle(draggedCard).boxShadow
+        : '',
+      normalShadow = normalCard ? getComputedStyle(normalCard).boxShadow : '';
+
+    await expect(draggedShadow).not.toBe(normalShadow);
+  },
 };
 
-export const HorizontalLayout = {
+export const HorizontalLayout: Story = {
   render: () => html`
     <section dir="ltr">
       <header><h2>Horizontal Layout</h2></header>
-      <p style="margin: 0 0 1rem; opacity: 0.7;">
+      <p class="ez-card__subtitle">
         Adding <code>ez-layout-horizontal</code> keeps a row flow regardless of
         text direction.
       </p>
@@ -297,65 +351,77 @@ export const HorizontalLayout = {
         style="display: flex; gap: 1rem; flex-wrap: wrap; max-width: 640px;"
       >
         <div class="ez-card ez-elevated ez-layout-horizontal">
-          <div class="ez-card__media">
-            <div
-              style="width: 140px; height: 100%; min-height: 140px; background: linear-gradient(135deg, #43e97b 0%, #38f9d7 100%);"
-            ></div>
-          </div>
+          <div
+            class="ez-card__media"
+            style="width: 140px; min-height: 140px; background: linear-gradient(135deg, #43e97b 0%, #38f9d7 100%);"
+          ></div>
           <div style="display: flex; flex-direction: column;">
             <div class="ez-card__header">
-              <h3 style="margin: 0;">Horizontal Elevated</h3>
-              <p style="margin: 0; opacity: 0.7;">Side-by-side layout</p>
+              <h3 class="ez-card__title">Horizontal Elevated</h3>
+              <p class="ez-card__subtitle">Side-by-side layout</p>
             </div>
-            <div class="ez-card__content">
-              <p style="margin: 0;">Media beside text content.</p>
+            <div class="ez-card__body">
+              <p>Media beside text content.</p>
             </div>
           </div>
         </div>
 
         <div class="ez-card ez-filled ez-layout-horizontal">
-          <div class="ez-card__media">
-            <div
-              style="width: 140px; height: 100%; min-height: 140px; background: linear-gradient(135deg, #f093fb 0%, #f5576c 100%);"
-            ></div>
-          </div>
+          <div
+            class="ez-card__media"
+            style="width: 140px; min-height: 140px; background: linear-gradient(135deg, #f093fb 0%, #f5576c 100%);"
+          ></div>
           <div style="display: flex; flex-direction: column;">
             <div class="ez-card__header">
-              <h3 style="margin: 0;">Horizontal Filled</h3>
-              <p style="margin: 0; opacity: 0.7;">Side-by-side layout</p>
+              <h3 class="ez-card__title">Horizontal Filled</h3>
+              <p class="ez-card__subtitle">Side-by-side layout</p>
             </div>
-            <div class="ez-card__content">
-              <p style="margin: 0;">Media beside text content.</p>
+            <div class="ez-card__body">
+              <p>Media beside text content.</p>
             </div>
           </div>
         </div>
 
         <div class="ez-card ez-outlined ez-layout-horizontal">
-          <div class="ez-card__media">
-            <div
-              style="width: 140px; height: 100%; min-height: 140px; background: linear-gradient(135deg, #a18cd1 0%, #fbc2eb 100%);"
-            ></div>
-          </div>
+          <div
+            class="ez-card__media"
+            style="width: 140px; min-height: 140px; background: linear-gradient(135deg, #a18cd1 0%, #fbc2eb 100%);"
+          ></div>
           <div style="display: flex; flex-direction: column;">
             <div class="ez-card__header">
-              <h3 style="margin: 0;">Horizontal Outlined</h3>
-              <p style="margin: 0; opacity: 0.7;">Side-by-side layout</p>
+              <h3 class="ez-card__title">Horizontal Outlined</h3>
+              <p class="ez-card__subtitle">Side-by-side layout</p>
             </div>
-            <div class="ez-card__content">
-              <p style="margin: 0;">Media beside text content.</p>
+            <div class="ez-card__body">
+              <p>Media beside text content.</p>
             </div>
           </div>
         </div>
       </div>
     </section>
   `,
+  play: async ({ canvasElement }) => {
+    const horizontalCards = canvasElement.querySelectorAll(
+      '.ez-card.ez-layout-horizontal'
+    );
+
+    await expect(horizontalCards.length).toBe(3);
+
+    await Promise.all(
+      Array.from(horizontalCards).map(async card => {
+        const media = card.querySelector('.ez-card__media');
+
+        await expect(media).toBeTruthy();
+      })
+    );
+  },
 };
 
-export const RTL = {
+export const RTL: Story = {
   render: () => html`
     <section dir="rtl">
       <header><h2>بطاقات RTL</h2></header>
-      <p style="margin: 0 0 1rem; opacity: 0.7;">
+      <p class="ez-card__subtitle">
         Cards in a right-to-left context. Default cards flow as rows in RTL;
         <code>ez-layout-vertical</code> preserves column flow.
       </p>
@@ -366,25 +432,25 @@ export const RTL = {
       >
         <button type="button" class="ez-card ez-elevated">
           <div class="ez-card__header">
-            <h3 style="margin: 0;">بطاقة مرتفعة</h3>
-            <p style="margin: 0; opacity: 0.7;">عنوان فرعي</p>
+            <h3 class="ez-card__title">بطاقة مرتفعة</h3>
+            <p class="ez-card__subtitle">عنوان فرعي</p>
           </div>
-          <div class="ez-card__content">
-            <p style="margin: 0;">Default RTL layout flows as a row.</p>
+          <div class="ez-card__body">
+            <p>Default RTL layout flows as a row.</p>
           </div>
         </button>
 
         <div class="ez-card ez-filled ez-layout-vertical">
           <div class="ez-card__header">
-            <h3 style="margin: 0;">بطاقة معبأة</h3>
-            <p style="margin: 0; opacity: 0.7;">عنوان فرعي</p>
+            <h3 class="ez-card__title">بطاقة معبأة</h3>
+            <p class="ez-card__subtitle">عنوان فرعي</p>
           </div>
-          <div class="ez-card__content">
-            <p style="margin: 0;">
+          <div class="ez-card__body">
+            <p>
               Explicit <code>ez-layout-vertical</code> keeps column flow in RTL.
             </p>
           </div>
-          <div class="ez-card__actions">
+          <div class="ez-card__footer">
             <button class="ez-btn ez-text" type="button">
               <ez-ripple></ez-ripple>إجراء
             </button>
@@ -392,21 +458,29 @@ export const RTL = {
         </div>
 
         <div class="ez-card ez-outlined">
-          <div class="ez-card__media" style="flex-shrink: 0;">
-            <div
-              style="height: 100%; min-height: 120px; background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);"
-            ></div>
-          </div>
+          <div
+            class="ez-card__media"
+            style="flex-shrink: 0; height: 100%; min-height: 120px; background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);"
+          ></div>
           <div style="display: flex; flex-direction: column;">
             <div class="ez-card__header">
-              <h3 style="margin: 0;">بطاقة محددة</h3>
+              <h3 class="ez-card__title">بطاقة محددة</h3>
             </div>
-            <div class="ez-card__content">
-              <p style="margin: 0;">RTL card with media beside text.</p>
+            <div class="ez-card__body">
+              <p>RTL card with media beside text.</p>
             </div>
           </div>
         </div>
       </div>
     </section>
   `,
+  play: async ({ canvasElement }) => {
+    const section = canvasElement.querySelector('section[dir="rtl"]');
+
+    await expect(section).toBeTruthy();
+
+    const cards = section?.querySelectorAll('.ez-card');
+
+    await expect(cards?.length).toBe(3);
+  },
 };

--- a/packages/ui/scss/modules/card.scss
+++ b/packages/ui/scss/modules/card.scss
@@ -1,3 +1,5 @@
+@import "../component-prelude";
+
 .ez-card {
   --_card-container-shape: var(--md-sys-shape-corner-medium, 12px);
 
@@ -124,12 +126,25 @@ html[dir="rtl"] .ez-card:not(.ez-layout-vertical) {
   padding: var(--md-sys-spacing-4, 1rem);
 }
 
-.ez-card__content {
-  padding: 0 var(--md-sys-spacing-4, 1rem) var(--md-sys-spacing-4, 1rem);
-  height: 100%;
+.ez-card__title {
+  @extend %md-typescale-title-medium;
+
+  margin: 0;
 }
 
-.ez-card__actions {
+.ez-card__subtitle {
+  @extend %md-typescale-body-medium;
+
+  margin: 0;
+  color: var(--md-sys-color-on-surface-variant, GrayText);
+}
+
+:where(.ez-card__body, .ez-card__content) {
+  padding: 0 var(--md-sys-spacing-4, 1rem) var(--md-sys-spacing-4, 1rem);
+  flex: 1;
+}
+
+:where(.ez-card__footer, .ez-card__actions) {
   display: flex;
   align-items: center;
   justify-content: flex-end;


### PR DESCRIPTION
## Summary

Closes #65

### CSS Changes (`scss/modules/card.scss`)
- Renamed `.ez-card__content` → `.ez-card__body` with backward-compat alias via `:where()`
- Renamed `.ez-card__actions` → `.ez-card__footer` with backward-compat alias via `:where()`
- Added `.ez-card__title` class with MD3 `title-medium` typescale
- Added `.ez-card__subtitle` class with MD3 `body-medium` typescale and `on-surface-variant` color
- Body element uses `flex: 1` for proper vertical layout fill

### Story Updates (`ez-card/index.stories.ts`)
- Replaced all inline `style="margin: 0;"` with `.ez-card__title` / `.ez-card__subtitle` classes
- Replaced inline `style="opacity: 0.7;"` with `.ez-card__subtitle` semantic class
- Updated `ez-card__content` → `ez-card__body` and `ez-card__actions` → `ez-card__footer`
- Moved media styling (gradients, dimensions) directly onto `.ez-card__media` elements
- Added `play` functions with assertions to all 7 stories

### Testing
- All 81 tests pass (14 test files, including 7 card story tests)
- Lint and build pass cleanly