### PR TITLE
chore(specs): format m3-lists.specs.md to match other spec files

### DIFF
--- a/md/specs/m3-lists.specs.md
+++ b/md/specs/m3-lists.specs.md
@@ -1,0 +1,257 @@
+# M3 Lists — Tokens & Specs
+
+> Source: [m3.material.io/components/lists/specs](https://m3.material.io/components/lists/specs)
+
+---
+
+## List
+
+### Color / Enabled
+
+| Description | Token | Value |
+|---|---|---|
+| List list item container color | `md.comp.list.list-item.container.color` | #FEF7FF |
+| List list item segmented container color | `md.comp.list.list-item.segmented.container.color` | #FEF7FF |
+| List list item label text color | `md.comp.list.list-item.label-text.color` | #1D1B20 |
+| List list item supporting text color | `md.comp.list.list-item.supporting-text.color` | #49454F |
+| List list item overline color | `md.comp.list.list-item.overline.color` | #49454F |
+| List list item divider color | `md.comp.list.divider.color` | #79747E |
+| List list item divider height | `md.comp.list.divider.height` | 1dp |
+| List list item container height | `md.comp.list.list-item.container.height` | 56dp |
+| One line list item container height | `md.comp.list.md.comp.list.list-item.one-line.container.height` | 56dp |
+| Three lines list item container height | `md.comp.list.md.comp.list.list-item.three-line.container.height` | 88dp |
+| Two lines list item container height | `md.comp.list.md.comp.list.list-item.two-line.container.height` | 72dp |
+| List list item leading icon color | `md.comp.list.list-item.leading-icon.color` | #49454F |
+| List list item trailing icon color | `md.comp.list.list-item.trailing-icon.color` | #49454F |
+| List list item unselected trailing icon color | `md.comp.list.list-item.unselected.trailing-icon.color` | #1D1B20 |
+| List list item trailing supporting text color | `md.comp.list.list-item.trailing-supporting-text.color` | #49454F |
+| List list item leading avatar color | `md.comp.list.list-item.leading-avatar.color` | #EADDFF |
+| List list item leading avatar label color | `md.comp.list.list-item.leading-avatar-label.color` | #4F378B |
+| List list item container elevation | `md.comp.list.list-item.container.elevation` | md.sys.elevation.level0 |
+
+### Color / Enabled - Selected
+
+| Description | Token | Value |
+|---|---|---|
+| List list item selected container color | `md.comp.list.list-item.selected.container.color` | #E8DEF8 |
+| List list item selected label text color | `md.comp.list.list-item.selected.label-text.color` | #4A4458 |
+| List list item selected supporting text color | `md.comp.list.list-item.selected.supporting-text.color` | #4A4458 |
+| List list item selected trailing supporting text color | `md.comp.list.list-item.selected.trailing-supporting-text.color` | #4A4458 |
+| List list item selected leading icon color | `md.comp.list.list-item.selected.leading-icon.color` | #4A4458 |
+| List list item selected trailing icon color | `md.comp.list.list-item.selected.trailing-icon.color` | #4A4458 |
+| List list item selected overline color | `md.comp.list.list-item.selected.overline.color` | #4A4458 |
+
+### Color / Disabled
+
+| Description | Token | Value |
+|---|---|---|
+| List list item disabled state layer color | `md.comp.list.list-item.disabled.state-layer.color` | #1D1B20 |
+| List list item disabled state layer opacity | `md.comp.list.list-item.disabled.state-layer.opacity` | 0.1 |
+| List list item disabled label text color | `md.comp.list.list-item.disabled.label-text.color` | #1D1B20 |
+| List list item disabled label text opacity | `md.comp.list.list-item.disabled.label-text.opacity` | 0.38 |
+| List list item disabled supporting text color | `md.comp.list.list-item.disabled.supporting-text.color` | #1D1B20 |
+| List list item disabled supporting text opacity | `md.comp.list.list-item.disabled.supporting-text.opacity` | 0.38 |
+| List list item disabled overline color | `md.comp.list.list-item.disabled.overline.color` | #1D1B20 |
+| List list item disabled overline opacity | `md.comp.list.list-item.disabled.overline.opacity` | 0.38 |
+| List list item disabled leading icon color | `md.comp.list.list-item.disabled.leading-icon.color` | #1D1B20 |
+| List list item disabled leading icon opacity | `md.comp.list.list-item.disabled.leading-icon.opacity` | 0.38 |
+| List list item disabled trailing icon color | `md.comp.list.list-item.disabled.trailing-icon.color` | #1D1B20 |
+| List list item disabled trailing icon opacity | `md.comp.list.list-item.disabled.trailing-icon.opacity` | 0.38 |
+
+### Color / Disabled - Selected
+
+| Description | Token | Value |
+|---|---|---|
+| List list item selected disabled container color | `md.comp.list.list-item.selected.disabled.container.color` | #1D1B20 |
+| List list item selected disabled container opacity | `md.comp.list.list-item.selected.disabled.container.opacity` | 0.38 |
+| List list item selected disabled label text color | `md.comp.list.list-item.selected.disabled.label-text.color` | #1D1B20 |
+| List list item selected disabled label text opacity | `md.comp.list.list-item.selected.disabled.label-text.opacity` | 0.38 |
+| List list item selected disabled supporting text color | `md.comp.list.list-item.selected.disabled.supporting-text.color` | #1D1B20 |
+| List list item selected disabled supporting text opacity | `md.comp.list.list-item.selected.disabled.supporting-text.opacity` | 0.38 |
+| List list item selected disabled trailing supporting text color | `md.comp.list.list-item.selected.disabled.trailing-supporting-text.color` | #1D1B20 |
+| List list item selected disabled trailing supporting text opacity | `md.comp.list.list-item.selected.disabled.trailing-supporting-text.opacity` | 0.38 |
+| List list item selected disabled overline color | `md.comp.list.list-item.selected.disabled.overline.color` | #1D1B20 |
+| List list item selected disabled overline opacity | `md.comp.list.list-item.selected.disabled.overline.opacity` | 0.38 |
+| List list item selected disabled state layer color | `md.comp.list.list-item.selected.disabled.state-layer.color` | #1D1B20 |
+| List list item selected disabled state layer opacity | `md.comp.list.list-item.selected.disabled.state-layer.opacity` | 0.1 |
+| List list item selected disabled leading icon color | `md.comp.list.list-item.selected.disabled.leading-icon.color` | #1D1B20 |
+| List list item selected disabled leading icon opacity | `md.comp.list.list-item.selected.disabled.leading-icon.opacity` | 0.38 |
+| List list item selected disabled trailing icon color | `md.comp.list.list-item.selected.disabled.trailing-icon.color` | #1D1B20 |
+| List list item selected disabled trailing icon opacity | `md.comp.list.list-item.selected.disabled.trailing-icon.opacity` | 0.38 |
+
+### Color / Hovered
+
+| Description | Token | Value |
+|---|---|---|
+| List list item hover state layer color | `md.comp.list.list-item.hover.state-layer.color` | #1D1B20 |
+| List list item hover state layer opacity | `md.comp.list.list-item.hover.state-layer.opacity` | 0.08 |
+| List list item hover label text color | `md.comp.list.list-item.hover.label-text.color` | #1D1B20 |
+| List list item hover leading icon color | `md.comp.list.list-item.hover.leading-icon.icon.color` | #49454F |
+| List list item hover trailing icon color | `md.comp.list.list-item.hover.trailing-icon.icon.color` | #49454F |
+
+### Color / Hovered - Selected
+
+| Description | Token | Value |
+|---|---|---|
+| List list item selected hover state layer color | `md.comp.list.list-item.selected.hover.state-layer.color` | #1D1B20 |
+| List list item selected hover state layer opacity | `md.comp.list.list-item.selected.hover.state-layer.opacity` | 0.08 |
+| List list item selected hover label text color | `md.comp.list.list-item.selected.hover.label-text.color` | #4A4458 |
+| List list item selected hover leading icon color | `md.comp.list.list-item.selected.hover.leading-icon.color` | #1D1B20 |
+| List list item selected hover trailing icon color | `md.comp.list.list-item.selected.hover.trailing-icon.color` | #1D1B20 |
+
+### Color / Focused
+
+| Description | Token | Value |
+|---|---|---|
+| List list item focus state layer color | `md.comp.list.list-item.focus.state-layer.color` | #1D1B20 |
+| List list item focus state layer opacity | `md.comp.list.list-item.focus.state-layer.opacity` | 0.1 |
+| List list item focus label text color | `md.comp.list.list-item.focus.label-text.color` | #1D1B20 |
+| List list item focus leading icon color | `md.comp.list.list-item.focus.leading-icon.icon.color` | #49454F |
+| List list item focus trailing icon color | `md.comp.list.list-item.focus.trailing-icon.icon.color` | #49454F |
+
+### Color / Focused / Focus indicator
+
+| Description | Token | Value |
+|---|---|---|
+| List list item focus indicator color | `md.comp.list.focus.indicator.color` | #625B71 |
+| List list item focus indicator thickness | `md.comp.list.focus.indicator.thickness` | 3dp |
+| List list item focus indicator offset | `md.comp.list.focus.indicator.outline.offset` | -3dp |
+
+### Color / Focused - Selected
+
+| Description | Token | Value |
+|---|---|---|
+| List list item selected focus state layer color | `md.comp.list.list-item.selected.focus.state-layer.color` | #1D1B20 |
+| List list item selected focus state layer opacity | `md.comp.list.list-item.selected.focus.state-layer.opacity` | 0.1 |
+| List list item selected focus label text color | `md.comp.list.list-item.selected.focus.label-text.color` | #4A4458 |
+| List list item selected focus leading icon color | `md.comp.list.list-item.selected.focus.leading-icon.color` | #1D1B20 |
+| List list item selected focus trailing icon color | `md.comp.list.list-item.selected.focus.trailing-icon.color` | #1D1B20 |
+
+### Color / Pressed (ripple)
+
+| Description | Token | Value |
+|---|---|---|
+| List list item pressed state layer color | `md.comp.list.list-item.pressed.state-layer.color` | #1D1B20 |
+| List list item pressed state layer opacity | `md.comp.list.list-item.pressed.state-layer.opacity` | 0.1 |
+| List list item pressed label text color | `md.comp.list.list-item.pressed.label-text.color` | #1D1B20 |
+| List list item pressed leading icon color | `md.comp.list.list-item.pressed.leading-icon.icon.color` | #49454F |
+| List list item pressed trailing icon color | `md.comp.list.list-item.pressed.trailing-icon.icon.color` | #49454F |
+
+### Color / Pressed - Selected
+
+| Description | Token | Value |
+|---|---|---|
+| List list item selected pressed state layer color | `md.comp.list.list-item.selected.pressed.state-layer.color` | #1D1B20 |
+| List list item selected pressed state layer opacity | `md.comp.list.list-item.selected.pressed.state-layer.opacity` | 0.1 |
+| List list item selected pressed label text color | `md.comp.list.list-item.selected.pressed.label-text.color` | #4A4458 |
+| List list item selected pressed trailing icon color | `md.comp.list.list-item.selected.pressed.trailing-icon.color` | #1D1B20 |
+| List list item selected pressed leading icon color | `md.comp.list.list-item.selected.pressed.leading-icon.color` | #1D1B20 |
+
+### Color / Dragged (baseline only)
+
+| Description | Token | Value |
+|---|---|---|
+| List list item dragged container color | `md.comp.list.list-item.dragged.container.elevation` | md.sys.elevation.level4 |
+| List list item dragged label text color | `md.comp.list.list-item.dragged.label-text.color` | #1D1B20 |
+| List list item selected dragged label text color | `md.comp.list.list-item.selected.dragged.label-text.color` | #4A4458 |
+| List list item dragged state layer color | `md.comp.list.list-item.dragged.state-layer.color` | #1D1B20 |
+| List list item dragged state layer opacity | `md.comp.list.list-item.dragged.state-layer.opacity` | 0.16 |
+| List list item selected dragged state layer color | `md.comp.list.list-item.selected.dragged.state-layer.color` | #1D1B20 |
+| List list item selected dragged state layer opacity | `md.comp.list.list-item.selected.dragged.state-layer.opacity` | 0.16 |
+| List list item dragged leading icon color | `md.comp.list.list-item.dragged.leading-icon.icon.color` | #49454F |
+| List list item selected dragged leading icon color | `md.comp.list.list-item.selected.dragged.leading-icon.color` | #1D1B20 |
+| List list item dragged trailing icon color | `md.comp.list.list-item.dragged.trailing-icon.icon.color` | #49454F |
+| List list item selected dragged trailing icon color | `md.comp.list.list-item.selected.dragged.trailing-icon.color` | #1D1B20 |
+
+### Spacing
+
+| Description | Token | Value |
+|---|---|---|
+| List list item leading space | `md.comp.list.list-item.leading-space` | 16dp |
+| List list item trailing space | `md.comp.list.list-item.trailing-space` | 16dp |
+| List list item top space | `md.comp.list.list-item.top-space` | 10dp |
+| List list item bottom space | `md.comp.list.list-item.bottom-space` | 10dp |
+| List list item between space | `md.comp.list.list-item.between-space` | 12dp |
+| List list item divider leading space | `md.comp.list.divider.leading-space` | 16dp |
+| List list item divider trailing space | `md.comp.list.divider.trailing-space` | 16dp |
+| List list item divider top space | `md.comp.list.divider.top-space` | 0 |
+| List list item divider bottom space | `md.comp.list.divider.bottom-space` | 0 |
+| List segment gap | `md.comp.list.segmented.gap` | 2dp |
+
+### Shape
+
+| Description | Token | Value |
+|---|---|---|
+| List container shape | `md.comp.list.container.shape` | md.sys.shape.corner.large |
+| List list item container shape | `md.comp.list.list-item.container.shape` | md.sys.shape.corner.none |
+| List list item container expressive shape | `md.comp.list.list-item.container.expressive.shape` | md.sys.shape.corner.extra-small |
+| List list item container disabled expressive shape | `md.comp.list.list-item.disabled.container.expressive.shape` | md.sys.shape.corner.extra-small |
+| List list item container hovered expressive shape | `md.comp.list.list-item.hovered.container.expressive.shape` | md.sys.shape.corner.medium |
+| List list item container focused expressive shape | `md.comp.list.list-item.focused.container.expressive.shape` | md.sys.shape.corner.large |
+| List list item container pressed expressive shape | `md.comp.list.list-item.pressed.container.expressive.shape` | md.sys.shape.corner.large |
+| List list item container dragged expressive shape | `md.comp.list.list-item.dragged.container.expressive.shape` | md.sys.shape.corner.large |
+| List list item container selected expressive shape | `md.comp.list.list-item.selected.container.expressive.shape` | md.sys.shape.corner.large |
+| List list item container selected disabled expressive shape | `md.comp.list.list-item.selected.disabled.container.expressive.shape` | md.sys.shape.corner.large |
+| List list item container selected hovered expressive shape | `md.comp.list.list-item.selected.hovered.container.expressive.shape` | md.sys.shape.corner.large |
+| List list item container selected focsued expressive shape | `md.comp.list.list-item.selected.focused.container.expressive.shape` | md.sys.shape.corner.large |
+| List list item container selected pressed expressive shape | `md.comp.list.list-item.selected.pressed.container.expressive.shape` | md.sys.shape.corner.large |
+| List list item container selected dragged expressive shape | `md.comp.list.list-item.selected.dragged.container.expressive.shape` | md.sys.shape.corner.large |
+| List list item leading avatar shape | `md.comp.list.list-item.leading-avatar.shape` | md.sys.shape.corner.full |
+| List list item leading video shape | `md.comp.list.list-item.leading-video.shape` | md.sys.shape.corner.small |
+| List list item leading image shape | `md.comp.list.list-item.leading-image.shape` | md.sys.shape.corner.none |
+| List list item leading image expressive shape | `md.comp.list.list-item.leading-image.expressive.shape` | md.sys.shape.corner.small |
+| List list item selected container shape | `md.comp.list.list-item.selected.container.shape` | md.sys.shape.corner.large |
+
+### Size and typography
+
+| Description | Token | Value |
+|---|---|---|
+| List list item leading avatar label type | `md.comp.list.list-item.leading-avatar-label.type` | Roboto 500 16pt/24pt 0.15pt |
+| List list item leading avatar size | `md.comp.list.list-item.leading-avatar.size` | 40dp |
+| List list item leading avatar label font | `md.comp.list.list-item.leading-avatar-label.font` | Roboto |
+| List list item leading avatar label line height | `md.comp.list.list-item.leading-avatar-label.line-height` | 24pt |
+| List list item leading avatar label size | `md.comp.list.list-item.leading-avatar-label.size` | 16pt |
+| List list item leading avatar label tracking | `md.comp.list.list-item.leading-avatar-label.tracking` | 0.15pt |
+| List list item leading avatar label weight | `md.comp.list.list-item.leading-avatar-label.weight` | 500 |
+| List list item leading icon size | `md.comp.list.list-item.leading-icon.size` | 24dp |
+| List list item leading icon expressive size | `md.comp.list.list-item.leading-icon.expressive.size` | 20dp |
+| List list item leading image width | `md.comp.list.list-item.leading-image.width` | 56dp |
+| List list item leading image height | `md.comp.list.list-item.leading-image.height` | 56dp |
+| List list item leading video width | `md.comp.list.list-item.leading-video.width` | 100dp |
+| List list item small leading video width | `md.comp.list.list-item.small.leading-video.width` | 100dp |
+| List list item small leading video height | `md.comp.list.list-item.small.leading-video.height` | 56dp |
+| List list item large leading video width | `md.comp.list.list-item.large.leading-video.width` | 114dp |
+| List list item large leading video height | `md.comp.list.list-item.large.leading-video.height` | 64dp |
+| One line list item container height | `md.comp.list.list-item.one-line.container.height` | 56dp |
+| Two lines list item container height | `md.comp.list.list-item.two-line.container.height` | 72dp |
+| Three lines list item container height | `md.comp.list.list-item.three-line.container.height` | 88dp |
+| List list item trailing icon size | `md.comp.list.list-item.trailing-icon.size` | 24dp |
+| List list item trailing icon expressive size | `md.comp.list.list-item.trailing-icon.expressive.size` | 20dp |
+| List list item label text type | `md.comp.list.list-item.label-text.type` | Roboto 400 16pt/24pt 0.5pt |
+| List list item label text font | `md.comp.list.list-item.label-text.font` | Roboto |
+| List list item label text line height | `md.comp.list.list-item.label-text.line-height` | 24pt |
+| List list item label text size | `md.comp.list.list-item.label-text.size` | 16pt |
+| List list item label text tracking | `md.comp.list.list-item.label-text.tracking` | 0.5pt |
+| List list item label text weight | `md.comp.list.list-item.label-text.weight` | 400 |
+| List list item trailing supporting text type | `md.comp.list.list-item.trailing-supporting-text.type` | Roboto 500 11pt/16pt 0.5pt |
+| List list item trailing supporting text font | `md.comp.list.list-item.trailing-supporting-text.font` | Roboto |
+| List list item trailing supporting text line height | `md.comp.list.list-item.trailing-supporting-text.line-height` | 16pt |
+| List list item trailing supporting text size | `md.comp.list.list-item.trailing-supporting-text.size` | 11pt |
+| List list item trailing supporting text tracking | `md.comp.list.list-item.trailing-supporting-text.tracking` | 0.5pt |
+| List list item trailing supporting text weight | `md.comp.list.list-item.trailing-supporting-text.weight` | 500 |
+| List list item supporting text type | `md.comp.list.list-item.supporting-text.type` | Roboto 400 14pt/20pt 0.25pt |
+| List list item supporting text font | `md.comp.list.list-item.supporting-text.font` | Roboto |
+| List list item supporting text line height | `md.comp.list.list-item.supporting-text.line-height` | 20pt |
+| List list item supporting text size | `md.comp.list.list-item.supporting-text.size` | 14pt |
+| List list item supporting text tracking | `md.comp.list.list-item.supporting-text.tracking` | 0.25pt |
+| List list item supporting text weight | `md.comp.list.list-item.supporting-text.weight` | 400 |
+| List list item overline type | `md.comp.list.list-item.overline.type` | Roboto 500 11pt/16pt 0.5pt |
+| List list item overline font | `md.comp.list.list-item.overline.font` | Roboto |
+| List list item overline line height | `md.comp.list.list-item.overline.line-height` | 16pt |
+| List list item overline size | `md.comp.list.list-item.overline.size` | 11pt |
+| List list item overline tracking | `md.comp.list.list-item.overline.tracking` | 0.5pt |
+| List list item overline weight | `md.comp.list.list-item.overline.weight` | 500 |
+
+---
+
+*Extracted from the Material Design 3 website on 2026-03-25.*


### PR DESCRIPTION
Restructures raw copied tokens from [m3.material.io/components/lists/specs](https://m3.material.io/components/lists/specs) into proper markdown matching the formatting used in other `md/specs/*.md` files:

- Added title, source link, and extraction footer
- Organized 171 tokens into 15 subsections with `### State / Category` headings
- Converted all entries into markdown tables (`| Description | Token | Value |`) with backtick-wrapped token names
- Combined typography "type" sub-properties into single-line values (e.g., `Roboto 500 16pt/24pt 0.15pt`)
- Removed "link" / "Copy link" scraping artifacts