### PR TITLE
refactor(ez-textfield): extend M3 textfield styles from input.scss base

### DIFF
--- a/packages/ui/ez-input/m3-textfield.stories.ts
+++ b/packages/ui/ez-input/m3-textfield.stories.ts
@@ -22,7 +22,7 @@ const textFieldInputTypes = [
 ] as const;
 
 /**
- * Helper that renders a standard .ez-m3-textfield with options.
+ * Helper that renders a standard .ez-textfield with options.
  */
 function renderTextField({
   variant = 'ez-filled',
@@ -58,7 +58,7 @@ function renderTextField({
   fullwidth?: boolean;
 } = {}) {
   const rootClasses = [
-    'ez-m3-textfield',
+    'ez-textfield',
     variant,
     stateClasses,
     fullwidth ? 'ez-fullwidth' : '',
@@ -71,16 +71,16 @@ function renderTextField({
 
   return html`
     <div class="${rootClasses}">
-      <div class="ez-m3-tf-wrapper">
-        <div class="ez-m3-tf-field">
+      <div class="ez-tf-wrapper">
+        <div class="ez-tf-field">
           ${leadingIcon
-            ? html`<div class="ez-m3-tf-leading">
+            ? html`<div class="ez-tf-leading">
                 <span class="md-icon">${leadingIcon}</span>
               </div>`
             : ''}
-          <div class="ez-m3-tf-center">
+          <div class="ez-tf-center">
             <input
-              class="ez-m3-tf-input"
+              class="ez-tf-input"
               type="${type}"
               placeholder="${placeholder}"
               id="${id}"
@@ -88,18 +88,18 @@ function renderTextField({
               ?disabled="${disabled}"
               ?required="${required}"
             />
-            <label class="ez-m3-tf-label" for="${id}">${label}</label>
+            <label class="ez-tf-label" for="${id}">${label}</label>
           </div>
           ${trailingIcon
-            ? html`<div class="ez-m3-tf-trailing">
+            ? html`<div class="ez-tf-trailing">
                 <span class="md-icon">${trailingIcon}</span>
               </div>`
             : ''}
         </div>
       </div>
-      ${helpText ? html`<div class="ez-m3-tf-help">${helpText}</div>` : ''}
+      ${helpText ? html`<div class="ez-tf-help">${helpText}</div>` : ''}
       ${messages.length
-        ? html`<ul class="ez-m3-tf-messages">
+        ? html`<ul class="ez-tf-messages">
             ${messages.map(m => html`<li>${m}</li>`)}
           </ul>`
         : ''}
@@ -108,7 +108,7 @@ function renderTextField({
 }
 
 /**
- * Helper that renders a .ez-m3-textfield wrapping a <select>.
+ * Helper that renders a .ez-textfield wrapping a <select>.
  */
 function renderSelectField({
   variant = 'ez-filled',
@@ -140,7 +140,7 @@ function renderSelectField({
   fullwidth?: boolean;
 } = {}) {
   const rootClasses = [
-    'ez-m3-textfield',
+    'ez-textfield',
     variant,
     fullwidth ? 'ez-fullwidth' : '',
     disabled ? 'ez-disabled' : '',
@@ -152,16 +152,16 @@ function renderSelectField({
 
   return html`
     <div class="${rootClasses}">
-      <div class="ez-m3-tf-wrapper">
-        <div class="ez-m3-tf-field">
+      <div class="ez-tf-wrapper">
+        <div class="ez-tf-field">
           ${leadingIcon
-            ? html`<div class="ez-m3-tf-leading">
+            ? html`<div class="ez-tf-leading">
                 <span class="md-icon">${leadingIcon}</span>
               </div>`
             : ''}
-          <div class="ez-m3-tf-center">
+          <div class="ez-tf-center">
             <select
-              class="ez-m3-tf-input"
+              class="ez-tf-input"
               id="${id}"
               .value="${value}"
               ?disabled="${disabled}"
@@ -177,18 +177,18 @@ function renderSelectField({
                   </option>`
               )}
             </select>
-            <label class="ez-m3-tf-label" for="${id}">${label}</label>
+            <label class="ez-tf-label" for="${id}">${label}</label>
           </div>
           ${trailingIcon
-            ? html`<div class="ez-m3-tf-trailing">
+            ? html`<div class="ez-tf-trailing">
                 <span class="md-icon">${trailingIcon}</span>
               </div>`
             : ''}
         </div>
       </div>
-      ${helpText ? html`<div class="ez-m3-tf-help">${helpText}</div>` : ''}
+      ${helpText ? html`<div class="ez-tf-help">${helpText}</div>` : ''}
       ${messages.length
-        ? html`<ul class="ez-m3-tf-messages">
+        ? html`<ul class="ez-tf-messages">
             ${messages.map(m => html`<li>${m}</li>`)}
           </ul>`
         : ''}
@@ -197,7 +197,7 @@ function renderSelectField({
 }
 
 /**
- * Helper that renders a .ez-m3-textfield wrapping a <textarea>.
+ * Helper that renders a .ez-textfield wrapping a <textarea>.
  */
 function renderTextareaField({
   variant = 'ez-filled',
@@ -227,7 +227,7 @@ function renderTextareaField({
   fullwidth?: boolean;
 } = {}) {
   const rootClasses = [
-    'ez-m3-textfield',
+    'ez-textfield',
     variant,
     fullwidth ? 'ez-fullwidth' : '',
     disabled ? 'ez-disabled' : '',
@@ -239,11 +239,11 @@ function renderTextareaField({
 
   return html`
     <div class="${rootClasses}">
-      <div class="ez-m3-tf-wrapper">
-        <div class="ez-m3-tf-field">
-          <div class="ez-m3-tf-center">
+      <div class="ez-tf-wrapper">
+        <div class="ez-tf-field">
+          <div class="ez-tf-center">
             <textarea
-              class="ez-m3-tf-input"
+              class="ez-tf-input"
               placeholder="${placeholder}"
               id="${id}"
               rows="${rows}"
@@ -251,13 +251,13 @@ function renderTextareaField({
               ?disabled="${disabled}"
               ?required="${required}"
             ></textarea>
-            <label class="ez-m3-tf-label" for="${id}">${label}</label>
+            <label class="ez-tf-label" for="${id}">${label}</label>
           </div>
         </div>
       </div>
-      ${helpText ? html`<div class="ez-m3-tf-help">${helpText}</div>` : ''}
+      ${helpText ? html`<div class="ez-tf-help">${helpText}</div>` : ''}
       ${messages.length
-        ? html`<ul class="ez-m3-tf-messages">
+        ? html`<ul class="ez-tf-messages">
             ${messages.map(m => html`<li>${m}</li>`)}
           </ul>`
         : ''}
@@ -317,7 +317,7 @@ export const FilledTextField: StoryObj = {
     </section>
   `,
   play: async ({ canvasElement }) => {
-    const textfields = canvasElement.querySelectorAll('.ez-m3-textfield');
+    const textfields = canvasElement.querySelectorAll('.ez-textfield');
 
     await expect(textfields.length).toBe(6);
 
@@ -325,11 +325,11 @@ export const FilledTextField: StoryObj = {
 
     await expect(filled.length).toBe(6);
 
-    const helpVisible = canvasElement.querySelector('.ez-m3-tf-help');
+    const helpVisible = canvasElement.querySelector('.ez-tf-help');
 
     await expect(helpVisible).not.toBeNull();
 
-    const messagesVisible = canvasElement.querySelector('.ez-m3-tf-messages');
+    const messagesVisible = canvasElement.querySelector('.ez-tf-messages');
 
     await expect(messagesVisible).not.toBeNull();
 
@@ -342,7 +342,7 @@ export const FilledTextField: StoryObj = {
     await expect(disabledField).not.toBeNull();
 
     const hasValueInput = canvasElement.querySelector<HTMLInputElement>(
-      '#filled-value .ez-m3-tf-input'
+      '#filled-value .ez-tf-input'
     );
 
     await expect(hasValueInput?.value).toBe('Hello world');
@@ -401,7 +401,7 @@ export const OutlinedTextField: StoryObj = {
     </section>
   `,
   play: async ({ canvasElement }) => {
-    const textfields = canvasElement.querySelectorAll('.ez-m3-textfield');
+    const textfields = canvasElement.querySelectorAll('.ez-textfield');
 
     await expect(textfields.length).toBe(6);
 
@@ -409,11 +409,11 @@ export const OutlinedTextField: StoryObj = {
 
     await expect(outlined.length).toBe(6);
 
-    const helpVisible = canvasElement.querySelector('.ez-m3-tf-help');
+    const helpVisible = canvasElement.querySelector('.ez-tf-help');
 
     await expect(helpVisible).not.toBeNull();
 
-    const messagesVisible = canvasElement.querySelector('.ez-m3-tf-messages');
+    const messagesVisible = canvasElement.querySelector('.ez-tf-messages');
 
     await expect(messagesVisible).not.toBeNull();
 
@@ -451,7 +451,7 @@ export const InputTypes: StoryObj = {
     </section>
   `,
   play: async ({ canvasElement }) => {
-    const inputs = canvasElement.querySelectorAll('.ez-m3-tf-input');
+    const inputs = canvasElement.querySelectorAll('.ez-tf-input');
 
     await expect(inputs.length).toBe(textFieldInputTypes.length);
 
@@ -543,7 +543,7 @@ export const TextFieldStates: StoryObj = {
   `,
   play: async ({ canvasElement }) => {
     const hasValueInput = canvasElement.querySelector<HTMLInputElement>(
-      '#state-has-value .ez-m3-tf-input'
+      '#state-has-value .ez-tf-input'
     );
 
     await expect(hasValueInput?.value).toBe('Some text');
@@ -556,23 +556,23 @@ export const TextFieldStates: StoryObj = {
 
     await expect(required).not.toBeNull();
 
-    const hasLeading = canvasElement.querySelector('.ez-m3-tf-leading');
+    const hasLeading = canvasElement.querySelector('.ez-tf-leading');
 
     await expect(hasLeading).not.toBeNull();
 
-    const hasTrailing = canvasElement.querySelector('.ez-m3-tf-trailing');
+    const hasTrailing = canvasElement.querySelector('.ez-tf-trailing');
 
     await expect(hasTrailing).not.toBeNull();
 
-    const hasHelp = canvasElement.querySelector('.ez-m3-tf-help');
+    const hasHelp = canvasElement.querySelector('.ez-tf-help');
 
     await expect(hasHelp).not.toBeNull();
 
-    const hasMessages = canvasElement.querySelector('.ez-m3-tf-messages');
+    const hasMessages = canvasElement.querySelector('.ez-tf-messages');
 
     await expect(hasMessages).not.toBeNull();
 
-    const messageLis = canvasElement.querySelectorAll('.ez-m3-tf-messages li');
+    const messageLis = canvasElement.querySelectorAll('.ez-tf-messages li');
 
     await expect(messageLis.length).toBe(2);
   },
@@ -685,16 +685,16 @@ export const LeadingTrailingIcons: StoryObj = {
     </section>
   `,
   play: async ({ canvasElement }) => {
-    const leadingIcons = canvasElement.querySelectorAll('.ez-m3-tf-leading');
+    const leadingIcons = canvasElement.querySelectorAll('.ez-tf-leading');
 
     await expect(leadingIcons.length).toBe(4);
 
-    const trailingIcons = canvasElement.querySelectorAll('.ez-m3-tf-trailing');
+    const trailingIcons = canvasElement.querySelectorAll('.ez-tf-trailing');
 
     await expect(trailingIcons.length).toBe(4);
 
     const bothIcons = canvasElement.querySelector(
-      '.ez-m3-tf-field:has(.ez-m3-tf-leading):has(.ez-m3-tf-trailing)'
+      '.ez-tf-field:has(.ez-tf-leading):has(.ez-tf-trailing)'
     );
 
     await expect(bothIcons).not.toBeNull();
@@ -774,13 +774,13 @@ export const ErrorStates: StoryObj = {
     await expect(outlinedError).not.toBeNull();
 
     const errorTrailing = canvasElement.querySelectorAll(
-      '.ez-error .ez-m3-tf-trailing'
+      '.ez-error .ez-tf-trailing'
     );
 
     await expect(errorTrailing.length).toBe(4);
 
     const errorMessages = canvasElement.querySelectorAll(
-      '.ez-error .ez-m3-tf-messages'
+      '.ez-error .ez-tf-messages'
     );
 
     await expect(errorMessages.length).toBe(3);
@@ -795,7 +795,7 @@ const sampleOptions = [
 ];
 
 /**
- * Select element rendered inside .ez-m3-textfield — filled and outlined variants.
+ * Select element rendered inside .ez-textfield — filled and outlined variants.
  */
 export const SelectTextField: StoryObj = {
   render: () => html`
@@ -873,13 +873,12 @@ export const SelectTextField: StoryObj = {
     </section>
   `,
   play: async ({ canvasElement }) => {
-    const textfields = canvasElement.querySelectorAll('.ez-m3-textfield');
+    const textfields = canvasElement.querySelectorAll('.ez-textfield');
 
     await expect(textfields.length).toBe(7);
 
-    const selects = canvasElement.querySelectorAll<HTMLSelectElement>(
-      'select.ez-m3-tf-input'
-    );
+    const selects =
+      canvasElement.querySelectorAll<HTMLSelectElement>('select.ez-tf-input');
 
     await expect(selects.length).toBe(7);
 
@@ -894,18 +893,18 @@ export const SelectTextField: StoryObj = {
 
     await expect(disabledSelect?.disabled).toBe(true);
 
-    const helpText = canvasElement.querySelector('.ez-m3-tf-help');
+    const helpText = canvasElement.querySelector('.ez-tf-help');
 
     await expect(helpText).not.toBeNull();
 
-    const errorMessages = canvasElement.querySelector('.ez-m3-tf-messages');
+    const errorMessages = canvasElement.querySelector('.ez-tf-messages');
 
     await expect(errorMessages).not.toBeNull();
   },
 };
 
 /**
- * Textarea element rendered inside .ez-m3-textfield — filled and outlined variants.
+ * Textarea element rendered inside .ez-textfield — filled and outlined variants.
  */
 export const TextareaTextField: StoryObj = {
   render: () => html`
@@ -976,12 +975,12 @@ export const TextareaTextField: StoryObj = {
     </section>
   `,
   play: async ({ canvasElement }) => {
-    const textfields = canvasElement.querySelectorAll('.ez-m3-textfield');
+    const textfields = canvasElement.querySelectorAll('.ez-textfield');
 
     await expect(textfields.length).toBe(7);
 
     const textareas = canvasElement.querySelectorAll<HTMLTextAreaElement>(
-      'textarea.ez-m3-tf-input'
+      'textarea.ez-tf-input'
     );
 
     await expect(textareas.length).toBe(7);
@@ -998,15 +997,15 @@ export const TextareaTextField: StoryObj = {
 
     await expect(disabledTextarea?.disabled).toBe(true);
 
-    const helpText = canvasElement.querySelector('.ez-m3-tf-help');
+    const helpText = canvasElement.querySelector('.ez-tf-help');
 
     await expect(helpText).not.toBeNull();
 
-    const errorMessages = canvasElement.querySelector('.ez-m3-tf-messages');
+    const errorMessages = canvasElement.querySelector('.ez-tf-messages');
 
     await expect(errorMessages).not.toBeNull();
 
-    const messageLis = canvasElement.querySelectorAll('.ez-m3-tf-messages li');
+    const messageLis = canvasElement.querySelectorAll('.ez-tf-messages li');
 
     await expect(messageLis.length).toBe(2);
   },

--- a/packages/ui/scss/modules/input/input.scss
+++ b/packages/ui/scss/modules/input/input.scss
@@ -9,6 +9,152 @@ html[dir="rtl"] :where(ez-input, .ez-input, .ez-textfield) {
   flex-flow: column nowrap;
 }
 
+/* -------------------------------------------------------
+ * M3 Textfield custom properties (shared by flat-DOM and
+ * wrapper-based textfield)
+ *
+ * Token priority: --md-color-* > --md-sys-color-* > --ez-* > system
+ * ------------------------------------------------------- */
+:where(ez-input, .ez-input, .ez-textfield) {
+  /* Typography */
+  --_tf-font-size: var(--md-sys-typescale-body-large-size, 1rem);
+  --_tf-font-family: var(--md-sys-typescale-body-large-font, inherit), sans-serif;
+  --_tf-font-weight: var(--md-sys-typescale-body-large-weight, 400);
+  --_tf-font-tracking: var(--md-sys-typescale-body-large-tracking, 0.5px);
+  --_tf-line-height: var(--md-sys-typescale-body-large-line-height, 1.5rem);
+  --_tf-font-size-small: var(--md-sys-typescale-body-small-size, 0.75rem);
+  --_tf-line-height-small: var(--md-sys-typescale-body-small-line-height, 1rem);
+  --_tf-font-tracking-small: var(--md-sys-typescale-body-small-tracking, 0.4px);
+
+  /* Layout */
+  --_tf-padding: calc(var(--_tf-font-size) / 2);
+  --_tf-label-padding: calc(var(--_tf-font-size) / 3);
+  --_tf-border-radius: var(--md-sys-shape-corner-extra-small, var(--ez-border-radius, 0.25rem));
+  --_tf-border-width: var(--ez-input-border-width, var(--ez-1px, 1px));
+
+  /* Motion */
+  --_tf-speed: var(--md-sys-motion-duration-short4, var(--ez-input-speed, 200ms));
+  --_tf-easing: var(--md-sys-motion-easing-standard, ease);
+
+  /* Colors — theme-aware */
+  --_tf-focus-color: var(--md-color-theme, var(--md-sys-color-primary, Highlight));
+  --_tf-surface-color: var(--md-sys-color-surface, Canvas);
+  --_tf-container-color: var(--md-sys-color-surface-container-highest, var(--ez-input-bg-color, Field));
+  --_tf-text-color: var(--md-sys-color-on-surface, var(--ez-input-text-color, FieldText));
+  --_tf-on-surface-variant: var(--md-sys-color-on-surface-variant, GrayText);
+  --_tf-label-color: var(--_tf-on-surface-variant);
+  --_tf-icon-color: var(--_tf-on-surface-variant);
+  --_tf-trailing-icon-color: var(--_tf-on-surface-variant);
+  --_tf-placeholder-color: var(--_tf-on-surface-variant);
+  --_tf-caret-color: var(--_tf-focus-color);
+  --_tf-outline-color: var(--md-sys-color-outline, currentcolor);
+  --_tf-supporting-text-color: var(--_tf-on-surface-variant);
+
+  /* Error */
+  --_tf-error-color: var(--md-sys-color-error, red);
+  --_tf-error-hover-color: var(--md-sys-color-on-error-container, darkred);
+
+  /* Disabled — per-element opacity per spec */
+  --_tf-disabled-color: var(--md-sys-color-on-surface, GrayText);
+  --_tf-disabled-content-opacity: var(--md-sys-state-disabled-content-opacity, 0.38);
+  --_tf-disabled-container-opacity: var(--md-sys-state-disabled-container-opacity, 0.12);
+
+  /* Active indicator (filled) */
+  --_tf-indicator-color: var(--_tf-on-surface-variant);
+  --_tf-indicator-height: var(--_tf-border-width);
+
+  /* Label transform */
+  --_tf-label-active-translateX: calc(-1 * var(--_tf-label-padding) - var(--_tf-border-width));
+  --_tf-label-active-translateY: calc((var(--_tf-padding) + var(--_tf-font-size-small)) * -1);
+  --_tf-label-active-transform: scale(0.89, 0.89) translate(var(--_tf-label-active-translateX), var(--_tf-label-active-translateY));
+}
+
+/* -------------------------------------------------------
+ * State-based property reassignment
+ * ------------------------------------------------------- */
+
+/* Hover (not focused) — filled: indicator → on-surface */
+:where(ez-input, .ez-input, .ez-textfield).ez-filled:not(:focus-within):hover {
+  --_tf-indicator-color: var(--_tf-text-color);
+}
+
+/* Hover (not focused) — outlined: outline + label → on-surface */
+:where(ez-input, .ez-input, .ez-textfield).ez-outlined:not(:focus-within):hover {
+  --_tf-outline-color: var(--_tf-text-color);
+  --_tf-label-color: var(--_tf-text-color);
+}
+
+/* Focus — root: label → focus-color */
+:where(ez-input, .ez-input, .ez-textfield):where(:focus-within) {
+  --_tf-label-color: var(--_tf-focus-color);
+}
+
+/* Focus — filled: indicator → focus-color, 2px */
+:where(ez-input, .ez-input, .ez-textfield).ez-filled:where(:focus-within) {
+  --_tf-indicator-color: var(--_tf-focus-color);
+  --_tf-indicator-height: 2px;
+}
+
+/* Focus — outlined: outline → focus-color, 2px */
+:where(ez-input, .ez-input, .ez-textfield).ez-outlined:where(:focus-within) {
+  --_tf-outline-color: var(--_tf-focus-color);
+  --_tf-border-width: 2px;
+}
+
+/* Error — root: label, caret, trailing, supporting → error-color */
+:where(ez-input, .ez-input, .ez-textfield):where(.ez-error, :has(:invalid)) {
+  --_tf-label-color: var(--_tf-error-color);
+  --_tf-caret-color: var(--_tf-error-color);
+  --_tf-trailing-icon-color: var(--_tf-error-color);
+  --_tf-supporting-text-color: var(--_tf-error-color);
+}
+
+/* Error — filled: indicator → error-color */
+:where(ez-input, .ez-input, .ez-textfield).ez-filled:where(.ez-error, :has(:invalid)) {
+  --_tf-indicator-color: var(--_tf-error-color);
+}
+
+/* Error — outlined: outline → error-color */
+:where(ez-input, .ez-input, .ez-textfield).ez-outlined:where(.ez-error, :has(:invalid)) {
+  --_tf-outline-color: var(--_tf-error-color);
+}
+
+/* Error + Focus — error overrides focus color */
+:where(ez-input, .ez-input, .ez-textfield):where(.ez-error, :has(:invalid)):focus-within {
+  --_tf-label-color: var(--_tf-error-color);
+  --_tf-caret-color: var(--_tf-error-color);
+  --_tf-trailing-icon-color: var(--_tf-error-color);
+  --_tf-supporting-text-color: var(--_tf-error-color);
+}
+
+:where(ez-input, .ez-input, .ez-textfield).ez-filled:where(.ez-error, :has(:invalid)):focus-within {
+  --_tf-indicator-color: var(--_tf-error-color);
+}
+
+:where(ez-input, .ez-input, .ez-textfield).ez-outlined:where(.ez-error, :has(:invalid)):focus-within {
+  --_tf-outline-color: var(--_tf-error-color);
+}
+
+/* Error + Hover (not focused) — label, trailing → error-hover-color */
+:where(ez-input, .ez-input, .ez-textfield):where(.ez-error, :has(:invalid)):not(:focus-within):hover {
+  --_tf-label-color: var(--_tf-error-hover-color);
+  --_tf-trailing-icon-color: var(--_tf-error-hover-color);
+}
+
+:where(ez-input, .ez-input, .ez-textfield).ez-filled:where(.ez-error, :has(:invalid)):not(:focus-within):hover {
+  --_tf-indicator-color: var(--_tf-error-hover-color);
+}
+
+:where(ez-input, .ez-input, .ez-textfield).ez-outlined:where(.ez-error, :has(:invalid)):not(:focus-within):hover {
+  --_tf-outline-color: var(--_tf-error-hover-color);
+}
+
+/* Disabled */
+:where(ez-input, .ez-input, .ez-textfield):where([disabled], .ez-disabled, :has(:disabled)) {
+  pointer-events: none;
+  cursor: not-allowed;
+}
+
 /**
  * Base
  * ------------------------ */
@@ -33,7 +179,7 @@ html:not([dir="rtl"]) :where(ez-input, .ez-input, .ez-textfield):where(
   padding: var(--ez-input-padding-block) var(--ez-input-padding-inline);
 }
 
-html:not([dir="rtl"]) :where(ez-input, .ez-input, .ez-textfield) > *:not(
+html:not([dir="rtl"]) :where(ez-input, .ez-input, .ez-textfield):where(:not(:has(.ez-tf-wrapper))) > *:not(
   [type="button"],
   [type="checkbox"],
   [type="color"],
@@ -67,7 +213,7 @@ html[dir="rtl"] :where(ez-input, .ez-input, .ez-textfield):is(
   padding: var(--ez-input-padding-inline) var(--ez-input-padding-block);
 }
 
-html[dir="rtl"] :where(ez-input, .ez-input, .ez-textfield) > *:not(
+html[dir="rtl"] :where(ez-input, .ez-input, .ez-textfield):where(:not(:has(.ez-tf-wrapper))) > *:not(
   [type="button"],
   [type="checkbox"],
   [type="color"],
@@ -84,7 +230,7 @@ html[dir="rtl"] :where(ez-input, .ez-input, .ez-textfield) > *:not(
 /**
  * Size control - Restrict heights for known control sizes.
  */
-:where(ez-input, .ez-input, .ez-textfield):not(.ez-small, .ez-large, textarea, :has(> textarea)) {
+:where(ez-input, .ez-input, .ez-textfield):where(:not(:has(.ez-tf-wrapper))):not(.ez-small, .ez-large, textarea, :has(> textarea)) {
   max-height: calc(36 / 16 * 1rem);
 }
 
@@ -104,7 +250,7 @@ html[dir="rtl"] :where(ez-input, .ez-input, .ez-textfield) > *:not(
 /**
  * Default dimensions, where not checkbox, and/or radio button.
  */
-:where(ez-input, .ez-input, .ez-textfield):not([type="checkbox"], [type="radio"]) {
+:where(ez-input, .ez-input, .ez-textfield):where(:not(:has(.ez-tf-wrapper))):not([type="checkbox"], [type="radio"]) {
   --ez-input-padding-block: var(--ez-6px);
   --ez-input-padding-inline: var(--ez-6px);
 
@@ -117,7 +263,7 @@ html[dir="rtl"] :where(ez-input, .ez-input, .ez-textfield) > *:not(
 /**
  * Default background.
  */
-:where(ez-input, .ez-input, .ez-textfield):has(
+:where(ez-input, .ez-input, .ez-textfield):where(:not(:has(.ez-tf-wrapper))):has(
   input:not(
     [type="button"],
     [type="checkbox"],
@@ -155,8 +301,8 @@ html[dir="rtl"] :where(ez-input, .ez-input, .ez-textfield) > *:not(
 /*
  * Input, Select, Textarea, and 'not checkbox, or radio'
  * ---------------------- */
-:where(ez-input, .ez-input, .ez-textfield):not([type="checkbox"], [type="radio"]),
-:where(ez-input, .ez-input, .ez-textfield) > :is(
+:where(ez-input, .ez-input, .ez-textfield):where(:not(:has(.ez-tf-wrapper))):not([type="checkbox"], [type="radio"]),
+:where(ez-input, .ez-input, .ez-textfield):where(:not(:has(.ez-tf-wrapper))) > :is(
   input:not([type="checkbox"], [type="radio"]),
   textarea,
   select
@@ -230,8 +376,8 @@ html[dir="rtl"] :where(ez-input, .ez-input, .ez-textfield) > *:not(
  * Outlined/Default
  * ----------------------- */
 :where(
-  :where(ez-input, .ez-input, .ez-textfield):not(.ez-underlined),
-  :where(ez-input, .ez-input, .ez-textfield).ez-outlined
+  :where(ez-input, .ez-input, .ez-textfield):where(:not(:has(.ez-tf-wrapper))):not(.ez-underlined),
+  :where(ez-input, .ez-input, .ez-textfield):where(:not(:has(.ez-tf-wrapper))).ez-outlined
 ):has(
   input:not([type="range"], [type="image"], [type="checkbox"], [type="radio"]),
   select,
@@ -260,38 +406,27 @@ html[dir="rtl"] :where(ez-input, .ez-input, .ez-textfield) > *:not(
 }
 
 /*
- * MD3 Filled variant
+ * MD3 Filled variant (flat DOM)
  * ----------------------- */
-:where(ez-input, .ez-input, .ez-textfield).ez-filled {
+:where(ez-input, .ez-input, .ez-textfield):where(:not(:has(.ez-tf-wrapper))).ez-filled {
   position: relative;
-  background: var(--md-sys-color-surface-container-highest, var(--ez-input-bg-color));
+  background: var(--_tf-container-color);
   border: none;
-  border-bottom: 1px solid var(--md-sys-color-on-surface-variant, currentcolor);
-  border-radius: var(--md-sys-shape-corner-extra-small, var(--ez-border-radius))
-    var(--md-sys-shape-corner-extra-small, var(--ez-border-radius))
-    0 0;
+  border-bottom: var(--_tf-indicator-height) solid var(--_tf-indicator-color);
+  border-radius: var(--_tf-border-radius) var(--_tf-border-radius) 0 0;
   min-height: 56px;
 }
 
-:where(ez-input, .ez-input, .ez-textfield).ez-filled:has(:focus) {
-  border-bottom-width: 2px;
-  border-bottom-color: var(--md-sys-color-primary, var(--ez-input-highlight-color));
-}
-
-:where(ez-input, .ez-input, .ez-textfield).ez-filled:has(:is(.ez-error, :invalid)) {
-  border-bottom-color: var(--md-sys-color-error, red);
-}
-
 /*
- * MD3 Outlined focus enhancement
+ * MD3 Outlined focus enhancement (flat DOM)
  * ----------------------- */
-:where(ez-input, .ez-input, .ez-textfield).ez-outlined:has(:focus) {
-  border-width: 2px;
-  border-color: var(--md-sys-color-primary, var(--ez-input-highlight-color));
+:where(ez-input, .ez-input, .ez-textfield):where(:not(:has(.ez-tf-wrapper))).ez-outlined:has(:focus) {
+  border-width: 3px;
+  border-color: var(--_tf-outline-color);
 }
 
-:where(ez-input, .ez-input, .ez-textfield).ez-outlined:has(:is(.ez-error, :invalid)) {
-  border-color: var(--md-sys-color-error, red);
+:where(ez-input, .ez-input, .ez-textfield):where(:not(:has(.ez-tf-wrapper))).ez-outlined:has(:is(.ez-error, :invalid)) {
+  border-color: var(--_tf-outline-color);
 }
 
 /*
@@ -303,33 +438,28 @@ html[dir="rtl"] :where(ez-input, .ez-input, .ez-textfield) > *:not(
   top: 50%;
   left: var(--ez-input-padding-inline, var(--ez-6px));
   transform: translateY(-50%);
-  font-size: var(--md-sys-typescale-body-large-size, 1.33333rem);
-  color: var(--md-sys-color-on-surface-variant, GrayText);
+  font-size: var(--_tf-font-size);
+  color: var(--_tf-label-color);
   pointer-events: none;
-  transition: transform var(--md-sys-motion-duration-short4, 200ms) var(--md-sys-motion-easing-standard, ease),
-              font-size var(--md-sys-motion-duration-short4, 200ms) var(--md-sys-motion-easing-standard, ease),
-              top var(--md-sys-motion-duration-short4, 200ms) var(--md-sys-motion-easing-standard, ease);
+  transition: transform var(--_tf-speed) var(--_tf-easing),
+              font-size var(--_tf-speed) var(--_tf-easing),
+              top var(--_tf-speed) var(--_tf-easing);
 }
 
 :where(ez-input, .ez-input, .ez-textfield).ez-filled:has(:focus, :not(:placeholder-shown)) > label {
   top: 8px;
   transform: translateY(0);
-  font-size: var(--md-sys-typescale-body-small-size, 1rem);
-  color: var(--md-sys-color-primary, var(--ez-input-highlight-color));
+  font-size: var(--_tf-font-size-small);
+  color: var(--_tf-label-color);
 }
 
 :where(ez-input, .ez-input, .ez-textfield).ez-outlined:has(:focus, :not(:placeholder-shown)) > label {
   top: 0;
   transform: translateY(-50%);
-  font-size: var(--md-sys-typescale-body-small-size, 1rem);
-  color: var(--md-sys-color-primary, var(--ez-input-highlight-color));
-  background: var(--md-sys-color-surface, Canvas);
+  font-size: var(--_tf-font-size-small);
+  color: var(--_tf-label-color);
+  background: var(--_tf-surface-color);
   padding-inline: 4px;
-}
-
-/* Error state label color */
-:where(ez-input, .ez-input, .ez-textfield):has(:is(.ez-error, :invalid):focus, :is(.ez-error, :invalid):not(:placeholder-shown)) > label {
-  color: var(--md-sys-color-error, red);
 }
 
 /*
@@ -339,14 +469,14 @@ html[dir="rtl"] :where(ez-input, .ez-input, .ez-textfield) > *:not(
   display: flex;
   align-items: center;
   padding-inline-start: var(--md-sys-spacing-3, 0.75rem);
-  color: var(--md-sys-color-on-surface-variant, GrayText);
+  color: var(--_tf-icon-color);
 }
 
 :where(ez-input, .ez-input, .ez-textfield) > .ez-field__trailing {
   display: flex;
   align-items: center;
   padding-inline-end: var(--md-sys-spacing-3, 0.75rem);
-  color: var(--md-sys-color-on-surface-variant, GrayText);
+  color: var(--_tf-trailing-icon-color);
 }
 
 @media (prefers-reduced-motion: reduce) {
@@ -359,7 +489,7 @@ html[dir="rtl"] :where(ez-input, .ez-input, .ez-textfield) > *:not(
 /**
  * Material Design - Input/Textfield
  * ---------------------- */
-:where(ez-input, .ez-input, .ez-textfield):not(
+:where(ez-input, .ez-input, .ez-textfield):where(:not(:has(.ez-tf-wrapper))):not(
   [type="checkbox"],
   [type="radio"]
 ):where(:focus-within) {

--- a/packages/ui/scss/modules/input/textfield.scss
+++ b/packages/ui/scss/modules/input/textfield.scss
@@ -1,5 +1,5 @@
 /**
- * .ez-m3-textfield — Material Design 3 Text Field (CSS-only)
+ * .ez-textfield — Material Design 3 Text Field (CSS-only)
  *
  * Spec: md/specs/m3-textfield.specs.md
  *
@@ -8,79 +8,22 @@
  * Also supports select and textarea elements.
  *
  * Structure:
- *   .ez-m3-textfield[.ez-filled|.ez-outlined]…
- *     .ez-m3-tf-wrapper
- *       .ez-m3-tf-field
- *         .ez-m3-tf-leading   (optional)
- *         .ez-m3-tf-center
- *           (input|select|textarea).ez-m3-tf-input[placeholder=" "]
- *           label.ez-m3-tf-label
- *         .ez-m3-tf-trailing  (optional)
- *     .ez-m3-tf-help          (optional)
- *     ul.ez-m3-tf-messages    (optional)
+ *   .ez-textfield[.ez-filled|.ez-outlined]…
+ *     .ez-tf-wrapper
+ *       .ez-tf-field
+ *         .ez-tf-leading   (optional)
+ *         .ez-tf-center
+ *           (input|select|textarea).ez-tf-input[placeholder=" "]
+ *           label.ez-tf-label
+ *         .ez-tf-trailing  (optional)
+ *     .ez-tf-help          (optional)
+ *     ul.ez-tf-messages    (optional)
  */
-
-/* -------------------------------------------------------
- * Custom properties (scoped to .ez-m3-textfield)
- *
- * Token priority: --md-color-* > --md-sys-color-* > --ez-* > system
- * ------------------------------------------------------- */
-:where(.ez-m3-textfield) {
-  /* Typography */
-  --_tf-font-size: var(--md-sys-typescale-body-large-size, 1rem);
-  --_tf-font-family: var(--md-sys-typescale-body-large-font, inherit), sans-serif;
-  --_tf-font-weight: var(--md-sys-typescale-body-large-weight, 400);
-  --_tf-font-tracking: var(--md-sys-typescale-body-large-tracking, 0.5px);
-  --_tf-line-height: var(--md-sys-typescale-body-large-line-height, 1.5rem);
-  --_tf-font-size-small: var(--md-sys-typescale-body-small-size, 0.75rem);
-  --_tf-line-height-small: var(--md-sys-typescale-body-small-line-height, 1rem);
-  --_tf-font-tracking-small: var(--md-sys-typescale-body-small-tracking, 0.4px);
-
-  /* Layout */
-  --_tf-padding: calc(var(--_tf-font-size) / 2);
-  --_tf-label-padding: calc(var(--_tf-font-size) / 3);
-  --_tf-border-radius: var(--md-sys-shape-corner-extra-small, var(--ez-border-radius, 0.25rem));
-  --_tf-border-width: var(--ez-input-border-width, var(--ez-1px, 1px));
-
-  /* Motion */
-  --_tf-speed: var(--md-sys-motion-duration-short4, var(--ez-input-speed, 200ms));
-  --_tf-easing: var(--md-sys-motion-easing-standard, ease);
-
-  /* Colors — theme-aware (--md-color-theme = primary by default) */
-  --_tf-focus-color: var(--md-color-theme, var(--md-sys-color-primary, Highlight));
-  --_tf-surface-color: var(--md-sys-color-surface, Canvas);
-  --_tf-container-color: var(--md-sys-color-surface-container-highest, var(--ez-input-bg-color, Field));
-  --_tf-text-color: var(--md-sys-color-on-surface, var(--ez-input-text-color, FieldText));
-  --_tf-on-surface-variant: var(--md-sys-color-on-surface-variant, GrayText);
-  --_tf-label-color: var(--_tf-on-surface-variant);
-  --_tf-icon-color: var(--_tf-on-surface-variant);
-  --_tf-placeholder-color: var(--_tf-on-surface-variant);
-  --_tf-caret-color: var(--_tf-focus-color);
-  --_tf-outline-color: var(--md-sys-color-outline, currentcolor);
-
-  /* Error */
-  --_tf-error-color: var(--md-sys-color-error, red);
-  --_tf-error-hover-color: var(--md-sys-color-on-error-container, darkred);
-
-  /* Disabled — per-element opacity per spec */
-  --_tf-disabled-color: var(--md-sys-color-on-surface, GrayText);
-  --_tf-disabled-content-opacity: var(--md-sys-state-disabled-content-opacity, 0.38);
-  --_tf-disabled-container-opacity: var(--md-sys-state-disabled-container-opacity, 0.12);
-
-  /* Active indicator (filled) */
-  --_tf-indicator-color: var(--_tf-on-surface-variant);
-  --_tf-indicator-height: var(--_tf-border-width);
-
-  /* Label transform */
-  --_tf-label-active-translateX: calc(-1 * var(--_tf-label-padding) - var(--_tf-border-width));
-  --_tf-label-active-translateY: calc((var(--_tf-padding) + var(--_tf-font-size-small)) * -1);
-  --_tf-label-active-transform: scale(0.89, 0.89) translate(var(--_tf-label-active-translateX), var(--_tf-label-active-translateY));
-}
 
 /* -------------------------------------------------------
  * Base
  * ------------------------------------------------------- */
-:where(.ez-m3-textfield) {
+:where(.ez-textfield) {
   position: relative;
   display: inline-block;
   user-select: none;
@@ -97,7 +40,7 @@
 /* -------------------------------------------------------
  * Wrapper
  * ------------------------------------------------------- */
-:where(.ez-m3-textfield) :where(.ez-m3-tf-wrapper) {
+:where(.ez-textfield) :where(.ez-tf-wrapper) {
   position: relative;
   background: transparent;
   transition: border-color var(--_tf-speed) var(--_tf-easing);
@@ -108,7 +51,7 @@
 /* -------------------------------------------------------
  * Field (flex row)
  * ------------------------------------------------------- */
-:where(.ez-m3-textfield) :where(.ez-m3-tf-field) {
+:where(.ez-textfield) :where(.ez-tf-field) {
   position: relative;
   display: flex;
   flex-direction: row;
@@ -122,8 +65,8 @@
 /* -------------------------------------------------------
  * Leading / Trailing icon areas (24dp per spec)
  * ------------------------------------------------------- */
-:where(.ez-m3-textfield) :where(.ez-m3-tf-leading),
-:where(.ez-m3-textfield) :where(.ez-m3-tf-trailing) {
+:where(.ez-textfield) :where(.ez-tf-leading),
+:where(.ez-textfield) :where(.ez-tf-trailing) {
   display: none;
   flex-direction: column;
   justify-content: space-around;
@@ -134,18 +77,19 @@
   color: var(--_tf-icon-color);
 }
 
-:where(.ez-m3-textfield) :where(.ez-m3-tf-leading) {
+:where(.ez-textfield) :where(.ez-tf-leading) {
   margin: 0 0 0 var(--_tf-padding);
 }
 
-:where(.ez-m3-textfield) :where(.ez-m3-tf-trailing) {
+:where(.ez-textfield) :where(.ez-tf-trailing) {
   margin: 0 var(--_tf-padding) 0 0;
+  color: var(--_tf-trailing-icon-color);
 }
 
 /* -------------------------------------------------------
  * Center area
  * ------------------------------------------------------- */
-:where(.ez-m3-textfield) :where(.ez-m3-tf-center) {
+:where(.ez-textfield) :where(.ez-tf-center) {
   position: relative;
   flex-basis: 100%;
   margin: 0;
@@ -154,7 +98,7 @@
 /* -------------------------------------------------------
  * Input element
  * ------------------------------------------------------- */
-:where(.ez-m3-textfield) :where(.ez-m3-tf-input) {
+:where(.ez-textfield) :where(.ez-tf-input) {
   position: relative;
   display: inline-block;
   padding: var(--_tf-padding);
@@ -172,11 +116,11 @@
   opacity: 0;
 }
 
-:where(.ez-m3-textfield) :where(.ez-m3-tf-input)::placeholder {
+:where(.ez-textfield) :where(.ez-tf-input)::placeholder {
   color: var(--_tf-placeholder-color);
 }
 
-:where(.ez-m3-textfield) :where(.ez-m3-tf-input):focus {
+:where(.ez-textfield) :where(.ez-tf-input):focus {
   outline: none;
   opacity: 1;
 }
@@ -184,7 +128,7 @@
 /* -------------------------------------------------------
  * Floating label
  * ------------------------------------------------------- */
-:where(.ez-m3-textfield) :where(.ez-m3-tf-label) {
+:where(.ez-textfield) :where(.ez-tf-label) {
   position: absolute;
   display: none;
   top: var(--_tf-border-width);
@@ -207,14 +151,14 @@
   background: none;
 }
 
-:where(.ez-m3-textfield) :where(.ez-m3-tf-label):hover {
+:where(.ez-textfield) :where(.ez-tf-label):hover {
   cursor: text;
 }
 
 /* -------------------------------------------------------
  * Required indicator
  * ------------------------------------------------------- */
-:where(.ez-m3-textfield):where([required], .ez-required, :has(:required)) :where(.ez-m3-tf-label)::before {
+:where(.ez-textfield):where([required], .ez-required, :has(:required)) :where(.ez-tf-label)::before {
   content: "*";
   color: var(--_tf-error-color);
 }
@@ -222,24 +166,19 @@
 /* -------------------------------------------------------
  * Focus-within — show input + activate label
  * ------------------------------------------------------- */
-:where(.ez-m3-textfield):focus-within :where(.ez-m3-tf-input) {
+:where(.ez-textfield):focus-within :where(.ez-tf-input) {
   opacity: 1;
 }
 
-:where(.ez-m3-textfield):focus-within :where(.ez-m3-tf-label) {
+:where(.ez-textfield):focus-within :where(.ez-tf-label) {
   transform: var(--_tf-label-active-transform);
-  color: var(--_tf-focus-color);
+  color: var(--_tf-label-color);
 }
 
 /* -------------------------------------------------------
- * Hover (not focused) — label / icon / input colors
+ * Hover (not focused) — input color
  * ------------------------------------------------------- */
-:where(.ez-m3-textfield):not(:focus-within):hover :where(.ez-m3-tf-input) {
-  color: var(--_tf-text-color);
-}
-
-/* Outlined hover: label → on-surface */
-:where(.ez-m3-textfield).ez-outlined:not(:focus-within):hover :where(.ez-m3-tf-label) {
+:where(.ez-textfield):not(:focus-within):hover :where(.ez-tf-input) {
   color: var(--_tf-text-color);
 }
 
@@ -249,30 +188,20 @@
  * Container = surface-container-highest
  * Active indicator = bottom border on field
  * ------------------------------------------------------- */
-:where(.ez-m3-textfield).ez-filled :where(.ez-m3-tf-wrapper) {
+:where(.ez-textfield).ez-filled :where(.ez-tf-wrapper) {
   background: var(--_tf-container-color);
   border-bottom: 1px solid transparent;
   border-radius: var(--_tf-border-radius) var(--_tf-border-radius) 0 0;
 }
 
-:where(.ez-m3-textfield).ez-filled :where(.ez-m3-tf-field) {
+:where(.ez-textfield).ez-filled :where(.ez-tf-field) {
   border-bottom: var(--_tf-indicator-height) solid var(--_tf-indicator-color);
   border-radius: var(--_tf-border-radius) var(--_tf-border-radius) 0 0;
 }
 
-/* Filled hover: active indicator → on-surface */
-:where(.ez-m3-textfield).ez-filled:not(:focus-within):hover :where(.ez-m3-tf-field) {
-  border-bottom-color: var(--_tf-text-color);
-}
-
-/* Filled focus: active indicator → primary/theme, 2px */
-:where(.ez-m3-textfield).ez-filled:focus-within :where(.ez-m3-tf-field) {
-  border-bottom-width: 2px;
-  border-bottom-color: var(--_tf-focus-color);
-}
-
-:where(.ez-m3-textfield).ez-filled:focus-within :where(.ez-m3-tf-wrapper) {
-  border-bottom-color: var(--_tf-focus-color);
+/* Filled focus: wrapper border visible */
+:where(.ez-textfield).ez-filled:focus-within :where(.ez-tf-wrapper) {
+  border-bottom-color: var(--_tf-indicator-color);
 }
 
 /* -------------------------------------------------------
@@ -280,206 +209,133 @@
  *
  * Outline = border on field
  * ------------------------------------------------------- */
-:where(.ez-m3-textfield).ez-outlined :where(.ez-m3-tf-wrapper) {
+:where(.ez-textfield).ez-outlined :where(.ez-tf-wrapper) {
   border: 1px solid transparent;
 }
 
-:where(.ez-m3-textfield).ez-outlined :where(.ez-m3-tf-field) {
+:where(.ez-textfield).ez-outlined :where(.ez-tf-field) {
   border: var(--_tf-border-width) solid var(--_tf-outline-color);
 }
 
-/* Outlined hover: outline → on-surface */
-:where(.ez-m3-textfield).ez-outlined:not(:focus-within):hover :where(.ez-m3-tf-field) {
-  border-color: var(--_tf-text-color);
+/* Outlined focus: wrapper border visible */
+:where(.ez-textfield).ez-outlined:focus-within :where(.ez-tf-wrapper) {
+  border-color: var(--_tf-outline-color);
 }
 
-/* Outlined focus: outline → primary/theme, thicker */
-:where(.ez-m3-textfield).ez-outlined:focus-within :where(.ez-m3-tf-field) {
-  border-width: 2px;
-  border-color: var(--_tf-focus-color);
+/* Outlined active label: surface background for notch effect */
+:where(.ez-textfield).ez-outlined:has(.ez-tf-input:not(:placeholder-shown)) :where(.ez-tf-label),
+:where(.ez-textfield).ez-outlined:focus-within :where(.ez-tf-label) {
+  background: var(--_tf-surface-color);
 }
 
-:where(.ez-m3-textfield).ez-outlined:focus-within :where(.ez-m3-tf-wrapper) {
-  border-color: var(--_tf-focus-color);
+/* -------------------------------------------------------
+ * Error + Focus — structural wrapper borders
+ * ------------------------------------------------------- */
+:where(.ez-textfield).ez-filled:where(.ez-error, :has(:invalid)):focus-within :where(.ez-tf-wrapper) {
+  border-bottom-color: var(--_tf-indicator-color);
+}
+
+:where(.ez-textfield).ez-outlined:where(.ez-error, :has(:invalid)):focus-within :where(.ez-tf-wrapper) {
+  border-color: var(--_tf-outline-color);
 }
 
 /* -------------------------------------------------------
  * Disabled (per-element color/opacity per spec)
  * ------------------------------------------------------- */
-:where(.ez-m3-textfield):where([disabled], .ez-disabled, :has(:disabled)) {
-  pointer-events: none;
-  cursor: not-allowed;
-}
-
-:where(.ez-m3-textfield):where([disabled], .ez-disabled, :has(:disabled)) :where(.ez-m3-tf-label),
-:where(.ez-m3-textfield):where([disabled], .ez-disabled, :has(:disabled)) :where(.ez-m3-tf-input),
-:where(.ez-m3-textfield):where([disabled], .ez-disabled, :has(:disabled)) :where(.ez-m3-tf-leading),
-:where(.ez-m3-textfield):where([disabled], .ez-disabled, :has(:disabled)) :where(.ez-m3-tf-trailing),
-:where(.ez-m3-textfield):where([disabled], .ez-disabled, :has(:disabled)) :where(.ez-m3-tf-help),
-:where(.ez-m3-textfield):where([disabled], .ez-disabled, :has(:disabled)) :where(.ez-m3-tf-messages) {
+:where(.ez-textfield):where([disabled], .ez-disabled, :has(:disabled)) :where(.ez-tf-label),
+:where(.ez-textfield):where([disabled], .ez-disabled, :has(:disabled)) :where(.ez-tf-input),
+:where(.ez-textfield):where([disabled], .ez-disabled, :has(:disabled)) :where(.ez-tf-leading),
+:where(.ez-textfield):where([disabled], .ez-disabled, :has(:disabled)) :where(.ez-tf-trailing),
+:where(.ez-textfield):where([disabled], .ez-disabled, :has(:disabled)) :where(.ez-tf-help),
+:where(.ez-textfield):where([disabled], .ez-disabled, :has(:disabled)) :where(.ez-tf-messages) {
   color: var(--_tf-disabled-color);
   opacity: var(--_tf-disabled-content-opacity);
 }
 
 /* Filled disabled: container + active indicator */
-:where(.ez-m3-textfield).ez-filled:where([disabled], .ez-disabled, :has(:disabled)) :where(.ez-m3-tf-wrapper) {
+:where(.ez-textfield).ez-filled:where([disabled], .ez-disabled, :has(:disabled)) :where(.ez-tf-wrapper) {
   background-color: var(--_tf-disabled-color);
   opacity: 0.04;
 }
 
-:where(.ez-m3-textfield).ez-filled:where([disabled], .ez-disabled, :has(:disabled)) :where(.ez-m3-tf-field) {
+:where(.ez-textfield).ez-filled:where([disabled], .ez-disabled, :has(:disabled)) :where(.ez-tf-field) {
   border-bottom-color: var(--_tf-disabled-color);
   opacity: var(--_tf-disabled-content-opacity);
 }
 
 /* Outlined disabled: outline */
-:where(.ez-m3-textfield).ez-outlined:where([disabled], .ez-disabled, :has(:disabled)) :where(.ez-m3-tf-field) {
+:where(.ez-textfield).ez-outlined:where([disabled], .ez-disabled, :has(:disabled)) :where(.ez-tf-field) {
   border-color: var(--_tf-disabled-color);
   opacity: var(--_tf-disabled-container-opacity);
 }
 
 /* -------------------------------------------------------
- * Error state
- * ------------------------------------------------------- */
-:where(.ez-m3-textfield):where(.ez-error, :has(:invalid)) :where(.ez-m3-tf-label) {
-  color: var(--_tf-error-color);
-}
-
-:where(.ez-m3-textfield):where(.ez-error, :has(:invalid)) :where(.ez-m3-tf-trailing) {
-  color: var(--_tf-error-color);
-}
-
-:where(.ez-m3-textfield):where(.ez-error, :has(:invalid)) :where(.ez-m3-tf-input) {
-  caret-color: var(--_tf-error-color);
-}
-
-:where(.ez-m3-textfield):where(.ez-error, :has(:invalid)) :where(.ez-m3-tf-help) {
-  color: var(--_tf-error-color);
-}
-
-:where(.ez-m3-textfield):where(.ez-error, :has(:invalid)) :where(.ez-m3-tf-messages) {
-  color: var(--_tf-error-color);
-}
-
-/* Error — filled active indicator */
-:where(.ez-m3-textfield).ez-filled:where(.ez-error, :has(:invalid)) :where(.ez-m3-tf-field) {
-  border-bottom-color: var(--_tf-error-color);
-}
-
-/* Error — outlined outline */
-:where(.ez-m3-textfield).ez-outlined:where(.ez-error, :has(:invalid)) :where(.ez-m3-tf-field) {
-  border-color: var(--_tf-error-color);
-}
-
-/* Error + Focus */
-:where(.ez-m3-textfield):where(.ez-error, :has(:invalid)):focus-within :where(.ez-m3-tf-label) {
-  color: var(--_tf-error-color);
-}
-
-:where(.ez-m3-textfield):where(.ez-error, :has(:invalid)):focus-within :where(.ez-m3-tf-trailing) {
-  color: var(--_tf-error-color);
-}
-
-:where(.ez-m3-textfield).ez-filled:where(.ez-error, :has(:invalid)):focus-within :where(.ez-m3-tf-field) {
-  border-bottom-color: var(--_tf-error-color);
-}
-
-:where(.ez-m3-textfield).ez-filled:where(.ez-error, :has(:invalid)):focus-within :where(.ez-m3-tf-wrapper) {
-  border-bottom-color: var(--_tf-error-color);
-}
-
-:where(.ez-m3-textfield).ez-outlined:where(.ez-error, :has(:invalid)):focus-within :where(.ez-m3-tf-field) {
-  border-color: var(--_tf-error-color);
-}
-
-:where(.ez-m3-textfield).ez-outlined:where(.ez-error, :has(:invalid)):focus-within :where(.ez-m3-tf-wrapper) {
-  border-color: var(--_tf-error-color);
-}
-
-/* Error + Hover (not focused) */
-:where(.ez-m3-textfield):where(.ez-error, :has(:invalid)):not(:focus-within):hover :where(.ez-m3-tf-label) {
-  color: var(--_tf-error-hover-color);
-}
-
-:where(.ez-m3-textfield):where(.ez-error, :has(:invalid)):not(:focus-within):hover :where(.ez-m3-tf-trailing) {
-  color: var(--_tf-error-hover-color);
-}
-
-:where(.ez-m3-textfield).ez-filled:where(.ez-error, :has(:invalid)):not(:focus-within):hover :where(.ez-m3-tf-field) {
-  border-bottom-color: var(--_tf-error-hover-color);
-}
-
-:where(.ez-m3-textfield).ez-outlined:where(.ez-error, :has(:invalid)):not(:focus-within):hover :where(.ez-m3-tf-field) {
-  border-color: var(--_tf-error-hover-color);
-}
-
-/* -------------------------------------------------------
  * Has-value state
  * ------------------------------------------------------- */
-:where(.ez-m3-textfield):has(.ez-m3-tf-input:not(:placeholder-shown)) :where(.ez-m3-tf-input) {
+:where(.ez-textfield):has(.ez-tf-input:not(:placeholder-shown)) :where(.ez-tf-input) {
   opacity: 1;
 }
 
-:where(.ez-m3-textfield):has(.ez-m3-tf-input:not(:placeholder-shown)) :where(.ez-m3-tf-label) {
+:where(.ez-textfield):has(.ez-tf-input:not(:placeholder-shown)) :where(.ez-tf-label) {
   transform: var(--_tf-label-active-transform);
 }
 
 /* -------------------------------------------------------
  * Help text (supporting text)
  * ------------------------------------------------------- */
-:where(.ez-m3-textfield) :where(.ez-m3-tf-help) {
+:where(.ez-textfield) :where(.ez-tf-help) {
   display: none;
   font-size: var(--_tf-font-size-small);
   line-height: var(--_tf-line-height-small);
   letter-spacing: var(--_tf-font-tracking-small);
   margin: calc(var(--_tf-font-size) / 3) var(--_tf-padding);
-  color: var(--_tf-on-surface-variant);
+  color: var(--_tf-supporting-text-color);
 }
 
 /* -------------------------------------------------------
  * Validation messages (supporting text — error)
  * ------------------------------------------------------- */
-:where(.ez-m3-textfield) :where(.ez-m3-tf-messages) {
+:where(.ez-textfield) :where(.ez-tf-messages) {
   display: none;
   padding: 0 0 0 var(--_tf-padding);
   margin: 0;
   font-size: var(--_tf-font-size-small);
   line-height: var(--_tf-line-height-small);
   letter-spacing: var(--_tf-font-tracking-small);
-  color: var(--_tf-error-color);
+  color: var(--_tf-supporting-text-color);
 }
 
 /* -------------------------------------------------------
  * Structural / value-based visibility
  * ------------------------------------------------------- */
-:where(.ez-m3-textfield):has(.ez-m3-tf-leading) :where(.ez-m3-tf-center) {
+:where(.ez-textfield):has(.ez-tf-leading) :where(.ez-tf-center) {
   margin-left: 0;
 }
 
-:where(.ez-m3-textfield):has(.ez-m3-tf-trailing) :where(.ez-m3-tf-center) {
+:where(.ez-textfield):has(.ez-tf-trailing) :where(.ez-tf-center) {
   margin-right: 0;
 }
 
-:where(.ez-m3-textfield):has(.ez-m3-tf-help) :where(.ez-m3-tf-help),
-:where(.ez-m3-textfield):has(.ez-m3-tf-messages) :where(.ez-m3-tf-messages) {
+:where(.ez-textfield):has(.ez-tf-help) :where(.ez-tf-help),
+:where(.ez-textfield):has(.ez-tf-messages) :where(.ez-tf-messages) {
   display: block;
 }
 
-:where(.ez-m3-textfield):has(.ez-m3-tf-leading) :where(.ez-m3-tf-leading),
-:where(.ez-m3-textfield):has(.ez-m3-tf-trailing) :where(.ez-m3-tf-trailing) {
+:where(.ez-textfield):has(.ez-tf-leading) :where(.ez-tf-leading),
+:where(.ez-textfield):has(.ez-tf-trailing) :where(.ez-tf-trailing) {
   display: flex;
 }
 
-:where(.ez-m3-textfield):has(.ez-m3-tf-label) :where(.ez-m3-tf-label) {
+:where(.ez-textfield):has(.ez-tf-label) :where(.ez-tf-label) {
   display: inline-block;
 }
 
 /* -------------------------------------------------------
  * Fullwidth
  * ------------------------------------------------------- */
-:where(.ez-m3-textfield).ez-fullwidth,
-:where(.ez-m3-textfield).ez-fullwidth :where(.ez-m3-tf-center),
-:where(.ez-m3-textfield).ez-fullwidth :where(.ez-m3-tf-input) {
+:where(.ez-textfield).ez-fullwidth,
+:where(.ez-textfield).ez-fullwidth :where(.ez-tf-center),
+:where(.ez-textfield).ez-fullwidth :where(.ez-tf-input) {
   flex-basis: 100%;
   width: 100%;
 }
@@ -488,12 +344,12 @@
  * Reduced motion
  * ------------------------------------------------------- */
 @media (prefers-reduced-motion: reduce) {
-  :where(.ez-m3-textfield) :where(.ez-m3-tf-label),
-  :where(.ez-m3-textfield) :where(.ez-m3-tf-input),
-  :where(.ez-m3-textfield) :where(.ez-m3-tf-field),
-  :where(.ez-m3-textfield) :where(.ez-m3-tf-wrapper),
-  :where(.ez-m3-textfield) :where(.ez-m3-tf-leading),
-  :where(.ez-m3-textfield) :where(.ez-m3-tf-trailing) {
+  :where(.ez-textfield) :where(.ez-tf-label),
+  :where(.ez-textfield) :where(.ez-tf-input),
+  :where(.ez-textfield) :where(.ez-tf-field),
+  :where(.ez-textfield) :where(.ez-tf-wrapper),
+  :where(.ez-textfield) :where(.ez-tf-leading),
+  :where(.ez-textfield) :where(.ez-tf-trailing) {
     transition: none;
   }
 }


### PR DESCRIPTION
## Summary

- Move shared M3 custom properties (`--_tf-*`) and state-based property reassignment rules (hover, focus, error, error+focus, error+hover, disabled) into `input.scss` so both flat-DOM inputs and the wrapper-based textfield share a single token contract via CSS custom property inheritance
- Rename `.ez-m3-textfield` → `.ez-textfield` and `.ez-m3-tf-*` → `.ez-tf-*` throughout styles and stories
- Slim `textfield.scss` from ~500 lines to ~355 by removing duplicate state logic now handled by property inheritance
- Add `:where(:not(:has(.ez-tf-wrapper)))` exclusions to flat-DOM structural rules in `input.scss` to prevent selector conflicts with the textfield component's nested DOM

## Test plan

- [ ] Run `pnpm storybook` and verify "M3 Input" stories render correctly (filled, outlined, all states)
- [ ] Verify "CSS Components/Input Controls" → MD3TextFields story still works (flat-DOM)
- [ ] Check hover, focus, error, error+focus, error+hover, disabled states in both variants
- [ ] Verify outlined label notch effect (background cutout) on focus and has-value
- [ ] `pnpm lintfix` passes
- [ ] `pnpm build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)