### PR TITLE
fix(ez-btn-group): #75 full-width buttons in connected vertical layout

### DIFF
--- a/packages/ui/scss/modules/button/button-group.scss
+++ b/packages/ui/scss/modules/button/button-group.scss
@@ -72,6 +72,11 @@
   border-radius: var(--_btn-container-shape);
 }
 
+/* Block (vertical) connected — full-width buttons */
+:where(.ez-button-group, .ez-btn-group):is(.ez-connected, [connected]).ez-layout-block > :where(.ez-btn, .ez-button) {
+  width: 100%;
+}
+
 /* Block (vertical) connected — override inline-direction corners for block-direction */
 :where(.ez-button-group, .ez-btn-group):is(.ez-connected, [connected]).ez-layout-block > :where(.ez-btn, .ez-button):first-child {
   border-start-start-radius: var(--_btn-container-shape);


### PR DESCRIPTION
## Summary
- Adds `width: 100%` to buttons inside connected vertical (`.ez-layout-block`) button groups so they form a unified vertical stack.

Closes #75

## Test plan
- [ ] Verify buttons stretch full width in connected vertical button groups via Storybook `VerticalLayout` story
- [ ] Confirm no visual regression in horizontal connected groups
- [ ] Lint and build pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)