### PR TITLE
fix(ez-tabs): #93 tabs fill full container height via button-level sizing

### DIFF
--- a/packages/ui/scss/modules/section.scss
+++ b/packages/ui/scss/modules/section.scss
@@ -1,49 +1,48 @@
 section > :where(
   header,
-  div > header
+  .ez-section__body > header,
+  .ez-section-body > header
 ) {
   padding: 1.5rem;
 }
 
 section > :where(
-  div,
   section,
-  div > section,
   article,
-  div > article
+  .ez-section__body,
+  .ez-section-body
 ) {
   border-top: var(--ez-1px) solid currentcolor;
 }
 
 section > :where(
-  div,
   section,
-  div > section,
   article,
-  div > article
+  .ez-section__body,
+  .ez-section-body
 ) > :where(
   header,
-  div > header
+  .ez-section__body > header,
+  .ez-section-body > header
 ) {
   padding: .5rem;
 }
 
 section > :where(
-  div,
   section,
-  div > section,
   article,
-  div > article
+  .ez-section__body,
+  .ez-section-body
 ) > :where(
   header,
-  div > header
+  .ez-section__body > header,
+  .ez-section-body > header
 ) + * {
   margin-top: 1rem;
 }
 
 section article,
 section > :where(
-  div,
   .ez-section__body,
   .ez-section-body
 ) {

--- a/packages/ui/scss/modules/tabs.scss
+++ b/packages/ui/scss/modules/tabs.scss
@@ -19,6 +19,8 @@
   position: relative;
   display: flex;
   flex-flow: row nowrap;
+  align-items: stretch;
+  padding: 0;
   background: var(--_tabs-container-color);
   border-bottom: var(--_tabs-divider-height) solid var(--_tabs-divider-color);
   overflow: auto visible;
@@ -67,6 +69,7 @@
   gap: 4px;
   padding: 12px 16px;
   min-width: 48px;
+  min-height: 48px;
   overflow: hidden;
   cursor: pointer;
   user-select: none;
@@ -123,7 +126,6 @@
 }
 
 :where(.ez-tabs.ez-primary, ez-tabs[variant="primary"]) > :where(.ez-tab, ez-tab) {
-  min-height: 48px;
   padding-bottom: 12px;
 
   /* Icon + label stacked: taller container */
@@ -179,10 +181,6 @@
     height: 2px;
     border-radius: 0;
   }
-}
-
-:where(.ez-tabs.ez-secondary, ez-tabs[variant="secondary"]) > :where(.ez-tab, ez-tab) {
-  min-height: 48px;
 }
 
 /* Active secondary tab */


### PR DESCRIPTION
Closes #93

## Changes

### `tabs.scss`
- **`align-items: stretch`** + **`padding: 0`** on `.ez-tabs` container — ensures tab buttons fill the full container height with no block padding.
- **`min-height: 48px`** moved to the base `.ez-tab` rule — previously duplicated in primary and secondary variant rules.

### `section.scss` (root cause)
- Removed bare `div` from all `section > :where(div, ...)` rules — this was the source of `padding: 1.5rem` leaking into component containers like `.ez-tabs` when nested inside a `<section>`.
- Section body padding now requires an explicit `.ez-section__body` or `.ez-section-body` class.
- `article` and nested `section` element selectors are preserved.

## Verification
- Build ✅
- Lint ✅
- 128 tests pass ✅
