### PR TITLE
feat(chip): #101 Implement Chip [CSS] component

### DIFF
--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -82,6 +82,7 @@ The library includes a comprehensive Material Design 3 design system built with 
 | **Button Group** | Grouped button layouts | Horizontal and vertical grouping |
 | **Badge** | Notification badges | Small/large, positioned, standalone |
 | **Card** | Container cards | Filled, Outlined, Elevated variants |
+| **Chip** | Compact elements for filters, selections, and actions | Assist, Filter, Input, Suggestion; checkbox/radio label pattern |
 | **Dialog** | Modal dialogs | Full-screen and standard dialogs |
 | **Divider** | Visual separators | Horizontal and vertical dividers |
 | **Field** | Form field containers | Material Design 3 field styling |

--- a/packages/ui/scss/modules/chip/assist.scss
+++ b/packages/ui/scss/modules/chip/assist.scss
@@ -1,0 +1,14 @@
+/**
+ * Assist Chip — .ez-assist
+ *
+ * Color: on-surface text, outline border, primary-colored leading icon.
+ * -------------------- */
+
+:where(.ez-btn, .ez-button).ez-chip.ez-assist {
+  color: var(--md-sys-color-on-surface, ButtonText);
+  border-color: var(--md-sys-color-outline, ButtonBorder);
+}
+
+:where(.ez-btn, .ez-button).ez-chip.ez-assist > .md-icon {
+  color: var(--md-sys-color-primary);
+}

--- a/packages/ui/scss/modules/chip/chip-set.scss
+++ b/packages/ui/scss/modules/chip/chip-set.scss
@@ -1,0 +1,10 @@
+/**
+ * Chip Set — flex-wrap layout container for chip groups.
+ * -------------------- */
+
+.ez-chip-set {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  align-items: center;
+}

--- a/packages/ui/scss/modules/chip/chip.scss
+++ b/packages/ui/scss/modules/chip/chip.scss
@@ -1,0 +1,88 @@
+/**
+ * Base Chip — built on .ez-btn
+ *
+ * Overrides button defaults for chip-specific sizing, shape, padding, and colors.
+ * Usage: <button class="ez-btn ez-chip ...">
+ * -------------------- */
+
+:where(.ez-btn, .ez-button).ez-chip {
+  --_btn-container-height: 32px;
+  --_btn-container-shape: 8px;
+  --_btn-icon-size: 18px;
+
+  min-height: var(--_btn-container-height);
+  border-radius: var(--_btn-container-shape);
+  padding-block: 0;
+  padding-inline: 16px;
+  gap: 8px;
+
+  /* Disable button shape-morph animation — chips have fixed 8px radius */
+  animation: none;
+
+  /* Default chip colors — outlined look */
+  background: transparent;
+  color: var(--md-sys-color-on-surface-variant, ButtonText);
+  border: 1px solid var(--md-sys-color-outline-variant, ButtonBorder);
+
+  /* Label typography — same as button label-large */
+  font-size: var(--md-sys-typescale-label-large-size, 1.16667rem);
+  font-weight: var(--md-sys-typescale-label-large-weight, 500);
+  letter-spacing: var(--md-sys-typescale-label-large-tracking, 0);
+  line-height: var(--md-sys-typescale-label-large-line-height, 1.66667rem);
+}
+
+/**
+ * Icon-aware padding — reduce padding on the side with an icon.
+ * -------------------- */
+
+/* Leading icon present — reduce padding-inline-start */
+:where(.ez-btn, .ez-button).ez-chip:has(
+  > :is(.md-icon, .ez-chip-avatar, .ez-chip-checkmark):first-child
+) {
+  padding-inline-start: 8px;
+}
+
+/* Trailing icon present — reduce padding-inline-end */
+:where(.ez-btn, .ez-button).ez-chip:has(
+  > :is(.md-icon, .ez-chip-close):last-child
+) {
+  padding-inline-end: 8px;
+}
+
+/* Leading icon present after hidden input (label pattern) */
+:where(.ez-btn, .ez-button).ez-chip:has(
+  > :is(input[type="checkbox"], input[type="radio"]) + :is(.md-icon, ez-ripple) + :is(.md-icon, .ez-chip-checkmark)
+) {
+  padding-inline-start: 8px;
+}
+
+:where(.ez-btn, .ez-button).ez-chip:has(
+  > :is(input[type="checkbox"], input[type="radio"]) + ez-ripple + :is(.md-icon, .ez-chip-checkmark)
+) {
+  padding-inline-start: 8px;
+}
+
+/**
+ * Ripple color override — chip uses on-surface-variant instead of theme color.
+ * -------------------- */
+:where(.ez-btn, .ez-button).ez-chip ez-ripple::after,
+:where(.ez-btn, .ez-button).ez-chip ez-ripple::before {
+  background: var(--md-sys-color-on-surface-variant);
+}
+
+/**
+ * Icon sizing within chips.
+ * -------------------- */
+:where(.ez-btn, .ez-button).ez-chip > .md-icon {
+  font-size: var(--_btn-icon-size);
+  width: var(--_btn-icon-size);
+  height: var(--_btn-icon-size);
+}
+
+/**
+ * Elevated chip — reuse button .ez-elevated but override background.
+ * -------------------- */
+:where(.ez-btn, .ez-button).ez-chip.ez-elevated {
+  border: none;
+  background: var(--md-sys-color-surface-container-low, ButtonFace);
+}

--- a/packages/ui/scss/modules/chip/chip.stories.ts
+++ b/packages/ui/scss/modules/chip/chip.stories.ts
@@ -1,0 +1,707 @@
+import { html } from 'lit';
+import { expect } from 'storybook/test';
+import type { StoryObj } from '@storybook/web-components-vite';
+import '../../../ez-ripple';
+
+export default {
+  title: 'CSS Components/Chip',
+};
+
+/**
+ * All 4 chip variants rendered side by side.
+ */
+export const ChipVariants: StoryObj = {
+  render: () => html`
+    <section>
+      <header><h2>Chip Variants</h2></header>
+
+      <div class="ez-section-body">
+        <div class="ez-chip-set">
+          <button class="ez-btn ez-chip ez-assist" type="button">
+            <ez-ripple></ez-ripple>
+            <span>Assist</span>
+          </button>
+
+          <button class="ez-btn ez-chip ez-filter" type="button">
+            <ez-ripple></ez-ripple>
+            <span class="md-icon ez-chip-checkmark">check</span>
+            <span>Filter</span>
+          </button>
+
+          <button class="ez-btn ez-chip ez-input" type="button">
+            <ez-ripple></ez-ripple>
+            <span>Input</span>
+            <span
+              class="md-icon ez-chip-close"
+              role="button"
+              aria-label="Remove Input"
+              >close</span
+            >
+          </button>
+
+          <button class="ez-btn ez-chip ez-suggestion" type="button">
+            <ez-ripple></ez-ripple>
+            <span>Suggestion</span>
+          </button>
+        </div>
+      </div>
+    </section>
+  `,
+  play: async ({ canvasElement }) => {
+    const chips = canvasElement.querySelectorAll('.ez-chip');
+
+    await expect(chips.length).toBe(4);
+    await expect(canvasElement.querySelector('.ez-assist')).toBeTruthy();
+    await expect(canvasElement.querySelector('.ez-filter')).toBeTruthy();
+    await expect(canvasElement.querySelector('.ez-input')).toBeTruthy();
+    await expect(canvasElement.querySelector('.ez-suggestion')).toBeTruthy();
+  },
+};
+
+/**
+ * Chips with leading icons, trailing close icons, and avatars.
+ */
+export const ChipWithIcons: StoryObj = {
+  render: () => html`
+    <section>
+      <header><h2>Chips with Icons</h2></header>
+
+      <div class="ez-section-body">
+        <h3>Assist — with leading icon</h3>
+        <div class="ez-chip-set">
+          <button class="ez-btn ez-chip ez-assist" type="button">
+            <ez-ripple></ez-ripple>
+            <span class="md-icon">event</span>
+            <span>Add to calendar</span>
+          </button>
+
+          <button class="ez-btn ez-chip ez-assist" type="button">
+            <ez-ripple></ez-ripple>
+            <span class="md-icon">directions</span>
+            <span>Get directions</span>
+          </button>
+
+          <button class="ez-btn ez-chip ez-assist" type="button">
+            <ez-ripple></ez-ripple>
+            <span class="md-icon">lightbulb</span>
+            <span>Turn on lights</span>
+          </button>
+        </div>
+
+        <br />
+
+        <h3>Filter — with trailing icon</h3>
+        <div class="ez-chip-set">
+          <button
+            class="ez-btn ez-chip ez-filter"
+            type="button"
+            aria-pressed="false"
+          >
+            <ez-ripple></ez-ripple>
+            <span class="md-icon ez-chip-checkmark">check</span>
+            <span>Documents</span>
+            <span class="md-icon">arrow_drop_down</span>
+          </button>
+
+          <button
+            class="ez-btn ez-chip ez-filter ez-selected"
+            type="button"
+            aria-pressed="true"
+          >
+            <ez-ripple></ez-ripple>
+            <span class="md-icon ez-chip-checkmark">check</span>
+            <span>Images</span>
+            <span class="md-icon">arrow_drop_down</span>
+          </button>
+        </div>
+
+        <br />
+
+        <h3>Input — with avatar and close icon</h3>
+        <div class="ez-chip-set" data-testid="input-chips-with-icons">
+          <button class="ez-btn ez-chip ez-input" type="button">
+            <ez-ripple></ez-ripple>
+            <img
+              class="ez-chip-avatar"
+              src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24'%3E%3Ccircle cx='12' cy='12' r='12' fill='%236750A4'/%3E%3Ctext x='12' y='16' text-anchor='middle' fill='white' font-size='12'%3EJD%3C/text%3E%3C/svg%3E"
+              alt=""
+            />
+            <span>Jane Doe</span>
+            <span
+              class="md-icon ez-chip-close"
+              role="button"
+              aria-label="Remove Jane Doe"
+              >close</span
+            >
+          </button>
+
+          <button class="ez-btn ez-chip ez-input" type="button">
+            <ez-ripple></ez-ripple>
+            <img
+              class="ez-chip-avatar"
+              src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24'%3E%3Ccircle cx='12' cy='12' r='12' fill='%23625B71'/%3E%3Ctext x='12' y='16' text-anchor='middle' fill='white' font-size='12'%3EJS%3C/text%3E%3C/svg%3E"
+              alt=""
+            />
+            <span>John Smith</span>
+            <span
+              class="md-icon ez-chip-close"
+              role="button"
+              aria-label="Remove John Smith"
+              >close</span
+            >
+          </button>
+        </div>
+
+        <br />
+
+        <h3>Suggestion — with leading icon</h3>
+        <div class="ez-chip-set">
+          <button class="ez-btn ez-chip ez-suggestion" type="button">
+            <ez-ripple></ez-ripple>
+            <span class="md-icon">search</span>
+            <span>Price: low to high</span>
+          </button>
+
+          <button class="ez-btn ez-chip ez-suggestion" type="button">
+            <ez-ripple></ez-ripple>
+            <span class="md-icon">star</span>
+            <span>Top rated</span>
+          </button>
+        </div>
+      </div>
+    </section>
+  `,
+  play: async ({ canvasElement }) => {
+    const avatars = canvasElement.querySelectorAll('.ez-chip-avatar'),
+      closeIcons = canvasElement.querySelectorAll('.ez-chip-close'),
+      leadingIcons = canvasElement.querySelectorAll('.ez-assist .md-icon');
+
+    await expect(avatars.length).toBe(2);
+    await expect(closeIcons.length).toBeGreaterThanOrEqual(2);
+    await expect(leadingIcons.length).toBe(3);
+  },
+};
+
+/**
+ * Disabled, selected, and elevated chip states.
+ */
+export const ChipStates: StoryObj = {
+  render: () => html`
+    <section>
+      <header><h2>Chip States</h2></header>
+
+      <div class="ez-section-body">
+        <h3>Disabled</h3>
+        <div class="ez-chip-set" data-testid="disabled-chips">
+          <button class="ez-btn ez-chip ez-assist" type="button" disabled>
+            <ez-ripple></ez-ripple>
+            <span class="md-icon">event</span>
+            <span>Disabled Assist</span>
+          </button>
+
+          <button class="ez-btn ez-chip ez-filter" type="button" disabled>
+            <ez-ripple></ez-ripple>
+            <span class="md-icon ez-chip-checkmark">check</span>
+            <span>Disabled Filter</span>
+          </button>
+
+          <button class="ez-btn ez-chip ez-input" type="button" disabled>
+            <ez-ripple></ez-ripple>
+            <span>Disabled Input</span>
+            <span class="md-icon ez-chip-close">close</span>
+          </button>
+
+          <button class="ez-btn ez-chip ez-suggestion" type="button" disabled>
+            <ez-ripple></ez-ripple>
+            <span>Disabled Suggestion</span>
+          </button>
+        </div>
+
+        <br />
+
+        <h3>Selected (via .ez-selected class)</h3>
+        <div class="ez-chip-set" data-testid="selected-chips">
+          <button
+            class="ez-btn ez-chip ez-filter ez-selected"
+            type="button"
+            aria-pressed="true"
+          >
+            <ez-ripple></ez-ripple>
+            <span class="md-icon ez-chip-checkmark">check</span>
+            <span>Selected Filter</span>
+          </button>
+
+          <button
+            class="ez-btn ez-chip ez-input ez-selected"
+            type="button"
+            aria-pressed="true"
+          >
+            <ez-ripple></ez-ripple>
+            <span>Selected Input</span>
+            <span
+              class="md-icon ez-chip-close"
+              role="button"
+              aria-label="Remove Selected Input"
+              >close</span
+            >
+          </button>
+        </div>
+
+        <br />
+
+        <h3>Elevated</h3>
+        <div class="ez-chip-set" data-testid="elevated-chips">
+          <button class="ez-btn ez-chip ez-assist ez-elevated" type="button">
+            <ez-ripple></ez-ripple>
+            <span class="md-icon">event</span>
+            <span>Elevated Assist</span>
+          </button>
+
+          <button class="ez-btn ez-chip ez-filter ez-elevated" type="button">
+            <ez-ripple></ez-ripple>
+            <span class="md-icon ez-chip-checkmark">check</span>
+            <span>Elevated Filter</span>
+          </button>
+
+          <button
+            class="ez-btn ez-chip ez-suggestion ez-elevated"
+            type="button"
+          >
+            <ez-ripple></ez-ripple>
+            <span>Elevated Suggestion</span>
+          </button>
+        </div>
+      </div>
+    </section>
+  `,
+  play: async ({ canvasElement }) => {
+    const disabledChips = canvasElement.querySelectorAll(
+        '[data-testid="disabled-chips"] .ez-chip'
+      ),
+      selectedChips = canvasElement.querySelectorAll(
+        '[data-testid="selected-chips"] .ez-chip'
+      ),
+      elevatedChips = canvasElement.querySelectorAll(
+        '[data-testid="elevated-chips"] .ez-chip'
+      );
+
+    await expect(disabledChips.length).toBe(4);
+    await expect(selectedChips.length).toBe(2);
+    await expect(elevatedChips.length).toBe(3);
+
+    await Promise.all(
+      Array.from(disabledChips).map(async chip => {
+        await expect((chip as HTMLButtonElement).disabled).toBe(true);
+      })
+    );
+
+    await Promise.all(
+      Array.from(selectedChips).map(async chip => {
+        await expect(chip.classList.contains('ez-selected')).toBe(true);
+        await expect(chip.getAttribute('aria-pressed')).toBe('true');
+      })
+    );
+
+    await Promise.all(
+      Array.from(elevatedChips).map(async chip => {
+        await expect(chip.classList.contains('ez-elevated')).toBe(true);
+      })
+    );
+  },
+};
+
+/**
+ * Filter chip set using `<label>` + `<input type="checkbox">` for
+ * multi-select — no JavaScript required.
+ */
+export const FilterChipCheckboxGroup: StoryObj = {
+  render: () => html`
+    <section>
+      <header>
+        <h2>Filter Chips — Checkbox (Multi-Select)</h2>
+        <p>
+          Uses native <code>&lt;input type="checkbox"&gt;</code> inside button
+          labels. Toggle selection by clicking — no JS needed.
+        </p>
+      </header>
+
+      <div class="ez-section-body">
+        <div
+          class="ez-chip-set"
+          role="group"
+          aria-label="Document filters"
+          data-testid="filter-checkbox"
+        >
+          ${['Docs', 'Slides', 'Sheets', 'Images', 'Videos'].map(
+            (label, i) => html`
+              <label class="ez-btn ez-chip ez-filter" for="fc-${i}">
+                <input
+                  type="checkbox"
+                  id="fc-${i}"
+                  name="filter-checkbox"
+                  value="${label.toLowerCase()}"
+                  ?checked=${label === 'Docs' || label === 'Images'}
+                />
+                <ez-ripple></ez-ripple>
+                <span class="md-icon ez-chip-checkmark">check</span>
+                <span>${label}</span>
+              </label>
+            `
+          )}
+        </div>
+      </div>
+    </section>
+  `,
+  play: async ({ canvasElement }) => {
+    const chipSet = canvasElement.querySelector(
+        '[data-testid="filter-checkbox"]'
+      ),
+      labels = chipSet?.querySelectorAll('label.ez-chip') ?? [],
+      checkboxes = chipSet?.querySelectorAll('input[type="checkbox"]') ?? [];
+
+    await expect(labels.length).toBe(5);
+    await expect(checkboxes.length).toBe(5);
+
+    const checkedBoxes =
+      chipSet?.querySelectorAll('input[type="checkbox"]:checked') ?? [];
+
+    await expect(checkedBoxes.length).toBe(2);
+  },
+};
+
+/**
+ * Filter chip set using `<label>` + `<input type="radio">` for
+ * single-select — no JavaScript required.
+ */
+export const FilterChipRadioGroup: StoryObj = {
+  render: () => html`
+    <section>
+      <header>
+        <h2>Filter Chips — Radio (Single-Select)</h2>
+        <p>
+          Uses native <code>&lt;input type="radio"&gt;</code> inside button
+          labels. Only one chip can be selected at a time.
+        </p>
+      </header>
+
+      <div class="ez-section-body">
+        <div
+          class="ez-chip-set"
+          role="radiogroup"
+          aria-label="Sort by"
+          data-testid="filter-radio"
+        >
+          ${['Price', 'Rating', 'Distance', 'Newest'].map(
+            (label, i) => html`
+              <label class="ez-btn ez-chip ez-filter" for="fr-${i}">
+                <input
+                  type="radio"
+                  id="fr-${i}"
+                  name="filter-radio"
+                  value="${label.toLowerCase()}"
+                  ?checked=${label === 'Rating'}
+                />
+                <ez-ripple></ez-ripple>
+                <span class="md-icon ez-chip-checkmark">check</span>
+                <span>${label}</span>
+              </label>
+            `
+          )}
+        </div>
+      </div>
+    </section>
+  `,
+  play: async ({ canvasElement }) => {
+    const chipSet = canvasElement.querySelector('[data-testid="filter-radio"]'),
+      labels = chipSet?.querySelectorAll('label.ez-chip') ?? [],
+      radios = chipSet?.querySelectorAll('input[type="radio"]') ?? [];
+
+    await expect(labels.length).toBe(4);
+    await expect(radios.length).toBe(4);
+
+    const checkedRadios =
+      chipSet?.querySelectorAll('input[type="radio"]:checked') ?? [];
+
+    await expect(checkedRadios.length).toBe(1);
+  },
+};
+
+/**
+ * Input chips in a set with avatars and close icons.
+ */
+export const InputChipSet: StoryObj = {
+  render: () => html`
+    <section>
+      <header>
+        <h2>Input Chip Set</h2>
+        <p>
+          Input chips represent user-entered data like contacts. Each has an
+          avatar and a remove button.
+        </p>
+      </header>
+
+      <div class="ez-section-body">
+        <h3>Recipients</h3>
+        <div
+          class="ez-chip-set"
+          role="group"
+          aria-label="Recipients"
+          data-testid="input-chipset"
+        >
+          ${[
+            { name: 'Alice Wang', initials: 'AW', color: '#6750A4' },
+            { name: 'Bob Chen', initials: 'BC', color: '#625B71' },
+            { name: 'Carol Davis', initials: 'CD', color: '#7D5260' },
+          ].map(
+            ({ name, initials, color }) => html`
+              <button class="ez-btn ez-chip ez-input" type="button">
+                <ez-ripple></ez-ripple>
+                <img
+                  class="ez-chip-avatar"
+                  src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24'%3E%3Ccircle cx='12' cy='12' r='12' fill='${encodeURIComponent(
+                    color
+                  )}'/%3E%3Ctext x='12' y='16' text-anchor='middle' fill='white' font-size='10'%3E${initials}%3C/text%3E%3C/svg%3E"
+                  alt=""
+                />
+                <span>${name}</span>
+                <span
+                  class="md-icon ez-chip-close"
+                  role="button"
+                  aria-label="Remove ${name}"
+                  >close</span
+                >
+              </button>
+            `
+          )}
+        </div>
+
+        <br />
+
+        <h3>Input chips — with icon (no avatar)</h3>
+        <div class="ez-chip-set" role="group" aria-label="Tags">
+          ${['JavaScript', 'TypeScript', 'CSS'].map(
+            tag => html`
+              <button class="ez-btn ez-chip ez-input" type="button">
+                <ez-ripple></ez-ripple>
+                <span class="md-icon">code</span>
+                <span>${tag}</span>
+                <span
+                  class="md-icon ez-chip-close"
+                  role="button"
+                  aria-label="Remove ${tag}"
+                  >close</span
+                >
+              </button>
+            `
+          )}
+        </div>
+
+        <br />
+
+        <h3>Input chip — selected state</h3>
+        <div class="ez-chip-set" role="group" aria-label="Selected input">
+          <button
+            class="ez-btn ez-chip ez-input ez-selected"
+            type="button"
+            aria-pressed="true"
+          >
+            <ez-ripple></ez-ripple>
+            <img
+              class="ez-chip-avatar"
+              src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24'%3E%3Ccircle cx='12' cy='12' r='12' fill='%236750A4'/%3E%3Ctext x='12' y='16' text-anchor='middle' fill='white' font-size='10'%3EAW%3C/text%3E%3C/svg%3E"
+              alt=""
+            />
+            <span>Alice Wang</span>
+            <span
+              class="md-icon ez-chip-close"
+              role="button"
+              aria-label="Remove Alice Wang"
+              >close</span
+            >
+          </button>
+
+          <button class="ez-btn ez-chip ez-input" type="button">
+            <ez-ripple></ez-ripple>
+            <img
+              class="ez-chip-avatar"
+              src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24'%3E%3Ccircle cx='12' cy='12' r='12' fill='%23625B71'/%3E%3Ctext x='12' y='16' text-anchor='middle' fill='white' font-size='10'%3EBC%3C/text%3E%3C/svg%3E"
+              alt=""
+            />
+            <span>Bob Chen</span>
+            <span
+              class="md-icon ez-chip-close"
+              role="button"
+              aria-label="Remove Bob Chen"
+              >close</span
+            >
+          </button>
+        </div>
+      </div>
+    </section>
+  `,
+  play: async ({ canvasElement }) => {
+    const chipSet = canvasElement.querySelector(
+        '[data-testid="input-chipset"]'
+      ),
+      chips = chipSet?.querySelectorAll('.ez-chip') ?? [],
+      avatars = chipSet?.querySelectorAll('.ez-chip-avatar') ?? [],
+      closeIcons = chipSet?.querySelectorAll('.ez-chip-close') ?? [];
+
+    await expect(chips.length).toBe(3);
+    await expect(avatars.length).toBe(3);
+    await expect(closeIcons.length).toBe(3);
+
+    await Promise.all(
+      Array.from(closeIcons).map(async icon => {
+        await expect(icon.getAttribute('role')).toBe('button');
+        await expect(icon.getAttribute('aria-label')).toBeTruthy();
+      })
+    );
+  },
+};
+
+/**
+ * Interactive behavior tests — chip sizing, border-radius, and selection.
+ */
+export const ChipInteraction: StoryObj = {
+  render: () => html`
+    <section>
+      <header><h2>Chip Interaction Tests</h2></header>
+
+      <div class="ez-section-body">
+        <div class="ez-chip-set" data-testid="interaction-chips">
+          <button
+            class="ez-btn ez-chip ez-assist"
+            type="button"
+            data-testid="chip-assist"
+          >
+            <ez-ripple></ez-ripple>
+            <span class="md-icon">event</span>
+            <span>Assist</span>
+          </button>
+
+          <button
+            class="ez-btn ez-chip ez-filter ez-selected"
+            type="button"
+            aria-pressed="true"
+            data-testid="chip-filter-selected"
+          >
+            <ez-ripple></ez-ripple>
+            <span class="md-icon ez-chip-checkmark">check</span>
+            <span>Selected</span>
+          </button>
+
+          <button
+            class="ez-btn ez-chip ez-filter"
+            type="button"
+            aria-pressed="false"
+            data-testid="chip-filter-unselected"
+          >
+            <ez-ripple></ez-ripple>
+            <span class="md-icon ez-chip-checkmark">check</span>
+            <span>Unselected</span>
+          </button>
+
+          <button
+            class="ez-btn ez-chip ez-suggestion"
+            type="button"
+            disabled
+            data-testid="chip-disabled"
+          >
+            <ez-ripple></ez-ripple>
+            <span>Disabled</span>
+          </button>
+        </div>
+
+        <br />
+
+        <div
+          class="ez-chip-set"
+          role="group"
+          aria-label="Checkbox interaction"
+          data-testid="interaction-checkbox"
+        >
+          <label class="ez-btn ez-chip ez-filter" for="ic-0">
+            <input
+              type="checkbox"
+              id="ic-0"
+              name="interaction-cb"
+              value="a"
+              checked
+            />
+            <ez-ripple></ez-ripple>
+            <span class="md-icon ez-chip-checkmark">check</span>
+            <span>Checked A</span>
+          </label>
+
+          <label class="ez-btn ez-chip ez-filter" for="ic-1">
+            <input type="checkbox" id="ic-1" name="interaction-cb" value="b" />
+            <ez-ripple></ez-ripple>
+            <span class="md-icon ez-chip-checkmark">check</span>
+            <span>Unchecked B</span>
+          </label>
+        </div>
+      </div>
+    </section>
+  `,
+  play: async ({ canvasElement }) => {
+    const assistChip = canvasElement.querySelector(
+        '[data-testid="chip-assist"]'
+      ),
+      selectedFilter = canvasElement.querySelector(
+        '[data-testid="chip-filter-selected"]'
+      ),
+      unselectedFilter = canvasElement.querySelector(
+        '[data-testid="chip-filter-unselected"]'
+      ),
+      disabledChip = canvasElement.querySelector(
+        '[data-testid="chip-disabled"]'
+      );
+
+    await expect(assistChip).toBeTruthy();
+    await expect(selectedFilter).toBeTruthy();
+    await expect(unselectedFilter).toBeTruthy();
+    await expect(disabledChip).toBeTruthy();
+
+    // Verify chip container height and border-radius
+    const assistStyle = getComputedStyle(assistChip as HTMLElement);
+
+    await expect(assistStyle.minHeight).toBe('32px');
+    await expect(assistStyle.borderRadius).toBe('8px');
+
+    // Verify selected filter has checkmark visible
+    const selectedCheckmark =
+      selectedFilter?.querySelector('.ez-chip-checkmark');
+
+    await expect(selectedCheckmark).toBeTruthy();
+
+    const selectedCheckStyle = getComputedStyle(
+      selectedCheckmark as HTMLElement
+    );
+
+    await expect(selectedCheckStyle.display).not.toBe('none');
+
+    // Verify unselected filter has checkmark hidden
+    const unselectedCheckmark =
+      unselectedFilter?.querySelector('.ez-chip-checkmark');
+
+    await expect(unselectedCheckmark).toBeTruthy();
+
+    const unselectedCheckStyle = getComputedStyle(
+      unselectedCheckmark as HTMLElement
+    );
+
+    await expect(unselectedCheckStyle.display).toBe('none');
+
+    // Verify disabled state
+    await expect((disabledChip as HTMLButtonElement).disabled).toBe(true);
+
+    // Verify checkbox checked state
+    const checkedInput = canvasElement.querySelector(
+      '[data-testid="interaction-checkbox"] input:checked'
+    );
+
+    await expect(checkedInput).toBeTruthy();
+    await expect((checkedInput as HTMLInputElement).value).toBe('a');
+  },
+};

--- a/packages/ui/scss/modules/chip/filter.scss
+++ b/packages/ui/scss/modules/chip/filter.scss
@@ -1,0 +1,64 @@
+/**
+ * Filter Chip — .ez-filter
+ *
+ * Supports selection via:
+ *   - aria-pressed="true" / aria-selected="true" / .ez-selected (JS toggle)
+ *   - :has(input:checked) (label + checkbox/radio, no JS)
+ * -------------------- */
+
+/* Selected state */
+:where(.ez-btn, .ez-button).ez-chip.ez-filter:is(
+  [aria-pressed="true"],
+  [aria-selected="true"],
+  .ez-selected,
+  :has(input:checked)
+) {
+  background: var(--md-sys-color-secondary-container);
+  color: var(--md-sys-color-on-secondary-container);
+  border-color: transparent;
+}
+
+/* Selected state ripple color */
+:where(.ez-btn, .ez-button).ez-chip.ez-filter:is(
+  [aria-pressed="true"],
+  [aria-selected="true"],
+  .ez-selected,
+  :has(input:checked)
+) ez-ripple::after,
+:where(.ez-btn, .ez-button).ez-chip.ez-filter:is(
+  [aria-pressed="true"],
+  [aria-selected="true"],
+  .ez-selected,
+  :has(input:checked)
+) ez-ripple::before {
+  background: var(--md-sys-color-on-secondary-container);
+}
+
+/* Selected icon color */
+:where(.ez-btn, .ez-button).ez-chip.ez-filter:is(
+  [aria-pressed="true"],
+  [aria-selected="true"],
+  .ez-selected,
+  :has(input:checked)
+) > .md-icon {
+  color: var(--md-sys-color-on-secondary-container);
+}
+
+/**
+ * Checkmark icon — hidden by default, shown when selected.
+ * -------------------- */
+:where(.ez-btn, .ez-button).ez-chip.ez-filter > .ez-chip-checkmark {
+  display: none;
+  font-size: 18px;
+  width: 18px;
+  height: 18px;
+}
+
+:where(.ez-btn, .ez-button).ez-chip.ez-filter:is(
+  [aria-pressed="true"],
+  [aria-selected="true"],
+  .ez-selected,
+  :has(input:checked)
+) > .ez-chip-checkmark {
+  display: inline-flex;
+}

--- a/packages/ui/scss/modules/chip/index.scss
+++ b/packages/ui/scss/modules/chip/index.scss
@@ -1,0 +1,6 @@
+@import "chip.scss";
+@import "assist.scss";
+@import "filter.scss";
+@import "input.scss";
+@import "suggestion.scss";
+@import "chip-set.scss";

--- a/packages/ui/scss/modules/chip/input.scss
+++ b/packages/ui/scss/modules/chip/input.scss
@@ -1,0 +1,74 @@
+/**
+ * Input Chip — .ez-input
+ *
+ * Supports avatar (24dp, 12dp radius), trailing close icon, and selection
+ * via the same 3 APIs as filter chips.
+ * -------------------- */
+
+/**
+ * Avatar support
+ * -------------------- */
+:where(.ez-btn, .ez-button).ez-chip.ez-input:has(> .ez-chip-avatar) {
+  padding-inline-start: 4px;
+}
+
+:where(.ez-btn, .ez-button).ez-chip.ez-input > .ez-chip-avatar {
+  width: 24px;
+  height: 24px;
+  border-radius: 12px;
+  object-fit: cover;
+  flex-shrink: 0;
+}
+
+/**
+ * Trailing close icon
+ * -------------------- */
+:where(.ez-btn, .ez-button).ez-chip.ez-input > .ez-chip-close {
+  font-size: 18px;
+  width: 18px;
+  height: 18px;
+  color: var(--md-sys-color-on-surface-variant);
+  cursor: pointer;
+  position: relative;
+  z-index: 4;
+}
+
+/**
+ * Selected state
+ * -------------------- */
+:where(.ez-btn, .ez-button).ez-chip.ez-input:is(
+  [aria-pressed="true"],
+  [aria-selected="true"],
+  .ez-selected,
+  :has(input:checked)
+) {
+  background: var(--md-sys-color-secondary-container);
+  color: var(--md-sys-color-on-secondary-container);
+  border-color: transparent;
+}
+
+/* Selected state ripple color */
+:where(.ez-btn, .ez-button).ez-chip.ez-input:is(
+  [aria-pressed="true"],
+  [aria-selected="true"],
+  .ez-selected,
+  :has(input:checked)
+) ez-ripple::after,
+:where(.ez-btn, .ez-button).ez-chip.ez-input:is(
+  [aria-pressed="true"],
+  [aria-selected="true"],
+  .ez-selected,
+  :has(input:checked)
+) ez-ripple::before {
+  background: var(--md-sys-color-on-secondary-container);
+}
+
+/* Selected close icon color */
+:where(.ez-btn, .ez-button).ez-chip.ez-input:is(
+  [aria-pressed="true"],
+  [aria-selected="true"],
+  .ez-selected,
+  :has(input:checked)
+) > .ez-chip-close {
+  color: var(--md-sys-color-on-secondary-container);
+}

--- a/packages/ui/scss/modules/chip/suggestion.scss
+++ b/packages/ui/scss/modules/chip/suggestion.scss
@@ -1,0 +1,9 @@
+/**
+ * Suggestion Chip — .ez-suggestion
+ *
+ * Uses outline border (not outline-variant) per spec.
+ * -------------------- */
+
+:where(.ez-btn, .ez-button).ez-chip.ez-suggestion {
+  border-color: var(--md-sys-color-outline, ButtonBorder);
+}

--- a/packages/ui/scss/modules/index.scss
+++ b/packages/ui/scss/modules/index.scss
@@ -22,3 +22,4 @@
 @import "menu.scss";
 @import "table.scss";
 @import "tabs.scss";
+@import "chip/index.scss";


### PR DESCRIPTION
## Summary

Implements the Material Design 3 Chip CSS component, built on the existing `.ez-btn` infrastructure (~60% CSS reuse).

Closes #101

## Changes

### SCSS files (`packages/ui/scss/modules/chip/`)
| File | Purpose |
|------|---------|
| `chip.scss` | Base `.ez-btn.ez-chip` overrides (32px height, 8px radius, 18px icons) |
| `assist.scss` | `.ez-assist` — on-surface text, outline border, primary icons |
| `filter.scss` | `.ez-filter` — selected state + checkmark toggle |
| `input.scss` | `.ez-input` — avatar support, trailing close icon |
| `suggestion.scss` | `.ez-suggestion` — outline border variant |
| `chip-set.scss` | `.ez-chip-set` — flex-wrap layout container (8px gap) |
| `index.scss` | Aggregator, registered in `modules/index.scss` |

### Stories (`chip.stories.ts`)
7 stories with `play` function assertions:
- **ChipVariants** — all 4 variants rendering
- **ChipWithIcons** — leading/trailing icon combinations
- **ChipStates** — selected, disabled, elevated
- **FilterChipCheckboxGroup** — label + checkbox (multi-select, no JS)
- **FilterChipRadioGroup** — label + radio (single-select, no JS)
- **InputChipSet** — chip-set layout with avatars + close icons
- **ChipInteraction** — computed style assertions (border-radius, checkmark, disabled)

### Other
- `README.md` — added Chip to CSS components table

## Key Features
- All 4 M3 chip variants: Assist, Filter, Input, Suggestion
- Selected state via `aria-pressed`, `.ez-selected`, or `:has(input:checked)`
- Label + checkbox/radio patterns for no-JS selection
- Elevated variant via existing `.ez-elevated` class
- Disables button shape-morph animation (chips have fixed 8px radius)

## Verification
- ✅ Lint passes (`pnpm lintfix`)
- ✅ Build passes (`pnpm build`)
- ✅ All 137 tests pass (`pnpm test`)