### PR TITLE
fix(ez-textfield): #107 layout shift, slotted focus ring, select/textarea label positioning

### DIFF
--- a/md/plans/fix-ez-textfield-overhaul.md
+++ b/md/plans/fix-ez-textfield-overhaul.md
@@ -1,0 +1,162 @@
+# Textfield Component — Comprehensive Fix Plan
+
+## Context
+
+The `ez-textfield` / `.ez-textfield` component has accumulated several interlocking defects that the user wants fixed together:
+
+1. **Layout shift on focus** (outlined + filled). Outlined jumps from `border: 1px` → `border: 3px` on focus (`textfield.scss:129-132, 210-213, 413-419`). Filled does the same at the bottom via `--_tf-indicator-width: 1px → 3px` (`:122-126, :200-207, :402-406`). A `.ez-textfield-border-container` CSS fix exists (`:519-561`) but is **not wired into `ez-textfield.ts`** — the custom element renders only `<div class="ez-textfield">`, so the layout-shift fix is bypassed for every `<ez-textfield>` usage.
+
+2. **Focus ring leaks onto slotted `input`/`select`/`textarea`.** `ez-textfield.ts` renders `.ez-textfield` inside **shadow DOM**, while the user's control is **slotted in from light DOM**. The shadow-DOM-scoped `outline: none` at `textfield.scss:348-350` cannot reach a slotted element. The global `focus-ring.scss:4-11` rule `:is(:not(.ez-textfield) > :is(select, textarea, input)):focus-visible` **matches** because, from the light-DOM perspective, the slotted input's parent is not `.ez-textfield` (that class lives in shadow DOM). Result: native focus ring on the inner control plus the container's ring — double outline.
+
+3. **Floating label mispositioned for `:has(select)` and `:has(textarea)`.** The "populated" trigger uses `:not(:placeholder-shown)`, which **never fires** on `<select>` (no placeholder concept) and on `<textarea>` only when a `placeholder` attribute is present. Additionally, the label uses `top: 50% + translateY(-50%)` (`:222-225, :353-370`) which centers vertically against the container — wrong for a tall multi-line textarea where it should sit at the top.
+
+4. **General jankiness.** Slotted inputs start at `opacity: 0` and fade in (`:334, :387-389`); label runs four simultaneous transitions (`:361-364`); the unused `.ez-textfield-border-container` CSS adds 43 lines of dead weight; redundant flat-DOM + structured-DOM rules duplicate intent.
+
+### Specs & prior art consulted
+
+- `md/specs/m3-textfield.specs.md` (tokens, focus 3dp outline, populated label 12pt)
+- `md/material-3/components/text-fields/specs.md` + `overview.md` + `guidelines.md`
+- `md/issues/ez-textfield-and-general-issues.md` (items 1 & 2 explicitly listed, author open to alternative for #2)
+- Existing patterns: `ez-ripple`, `ez-field`, `packages/ui/scss/modules/button/outlined.scss` (padding-compensation pattern)
+
+### Why this matters
+
+Every `<ez-textfield>` in every form flashes/jumps on focus and double-outlines on focus-visible. Users of the library will hit this on first render — it is table-stakes correctness, not polish.
+
+---
+
+## Recommended Approach: Box-Shadow-Driven Borders
+
+Replace width-changing borders with **box-shadow** for the outline and bottom indicator. `box-shadow` does not participate in layout, so a 1px → 3px change is purely visual — no layout shift, no wrapper element needed, no parallel "border container" class to maintain.
+
+This supersedes the existing `.ez-textfield-border-container` approach (which works but requires every user to wrap outlined textfields in an extra `<div>`, and which the custom element fails to do for itself).
+
+### Critical files to modify
+
+| File | Scope |
+|---|---|
+| `packages/ui/scss/modules/input/textfield.scss` | Main refactor: box-shadow borders/indicators, label positioning for select/textarea, remove dead `.ez-textfield-border-container` block, simplify transitions |
+| `packages/ui/scss/modules/focus-ring.scss` | Add `ez-textfield` (custom-element tag) to the suppressed-descendant selector so slotted controls don't pick up a light-DOM outline |
+| `packages/ui/ez-textfield/ez-textfield.scss` | Add `::slotted(input:focus-visible), ::slotted(select:focus-visible), ::slotted(textarea:focus-visible) { outline: none }` to reach into light DOM from shadow DOM |
+| `packages/ui/ez-textfield/ez-textfield.stories.ts` | Remove `ez-textfield-border-container` wrappers from `renderTextField`, `renderSelectField`, `renderTextareaField` helpers (lines ~92, ~180, ~251); update play-function selectors |
+| `packages/ui/scss/modules/input/input-controls.stories.ts` (if present) | Same removal |
+
+### Fix details
+
+**Fix A — Outlined layout shift (textfield.scss)**
+Replace the `.ez-outlined` rules (`:210-213, :413-419`) with:
+```scss
+:where(.ez-textfield).ez-outlined {
+  border: none;
+  box-shadow: inset 0 0 0 var(--_tf-border-width) var(--_tf-outline-color);
+  transition: box-shadow var(--_tf-speed) var(--_tf-easing);
+}
+:where(.ez-textfield).ez-outlined:focus-within {
+  box-shadow: inset 0 0 0 3px var(--_tf-outline-color);
+}
+```
+Remove the `--_tf-border-width: 3px` reassignment on focus (`:129-132`) — only the color token should change on focus; width change is now in the box-shadow rule itself. Remove the entire `.ez-textfield-border-container` block (`:500-561`).
+
+**Fix B — Filled indicator layout shift (textfield.scss)**
+Replace `border-bottom: var(--_tf-indicator-width) ...` (`:204, :404`) with:
+```scss
+:where(.ez-textfield).ez-filled {
+  border: none;
+  box-shadow: inset 0 calc(-1 * var(--_tf-indicator-width)) 0 0 var(--_tf-indicator-color);
+}
+```
+This preserves the existing `--_tf-indicator-width: 1px → 3px` state reassignment at `:122-126` but the change no longer affects layout.
+
+**Fix C — Suppress focus ring on slotted controls (ez-textfield.scss)**
+Add:
+```scss
+:host ::slotted(input:focus-visible),
+:host ::slotted(select:focus-visible),
+:host ::slotted(textarea:focus-visible) {
+  outline: none;
+}
+```
+And in `focus-ring.scss`, update the selector to exclude descendants of the `ez-textfield` custom element:
+```scss
+:is(:not(.ez-textfield, ez-textfield) > :is(select, textarea, input)):focus-visible { ... }
+```
+Keep the `.ez-textfield:has(:focus-visible)` host-ring rule — that's correct.
+
+**Fix D — Floating label for `<select>` and `<textarea>` (textfield.scss)**
+- For `<select>`: selects are always "populated" in the user's mental model (there's always a selected option). Float the label unconditionally when the textfield contains a select:
+  ```scss
+  :where(.ez-textfield):has(select) :where(.ez-textfield-label) {
+    transform: var(--_tf-label-active-transform);
+  }
+  ```
+- For `<textarea>`: align the label to the top (not vertical-center) and use `:placeholder-shown` as today (requires `placeholder=" "` trick, which is already the convention and documented):
+  ```scss
+  :where(.ez-textfield):has(textarea) :where(.ez-textfield-label) {
+    top: var(--_tf-padding);
+    transform: translateY(0);
+  }
+  :where(.ez-textfield):has(textarea):focus-within :where(.ez-textfield-label),
+  :where(.ez-textfield):has(textarea:not(:placeholder-shown)) :where(.ez-textfield-label) {
+    transform: var(--_tf-label-active-transform);
+  }
+  ```
+- Apply the same adjustment to the flat-DOM `> label` path at `:220-248`.
+
+**Fix E — Remove jank sources (textfield.scss)**
+- Drop `opacity: 0 → 1` on slotted controls (`:334, :387-389, :464-466`). The populated-label animation already conveys the state change; fading the input text adds nothing and stutters on slow devices.
+- Narrow the label's transition list to `transform, color` only — drop `background` and `border-color` (label has neither that changes meaningfully).
+- Delete the entire `.ez-textfield-border-container` block and its disabled/error variants (no longer referenced).
+
+**Fix F — Story / helper cleanup (ez-textfield.stories.ts)**
+- Remove `ez-textfield-border-container` wrapper construction from the three helpers (`:92-101, :180-189, :251-260`).
+- Leave play-function assertions unchanged where possible; update any selector that queried `.ez-textfield-border-container`.
+
+### Reused existing utilities
+
+- `--_tf-*` token system in `textfield.scss:46-100` — keep as-is.
+- `@extend %md-typescale-body-large` / `%md-typescale-body-small` — keep for typography.
+- `focus-ring.scss` global rule — reuse with the single selector tweak in Fix C.
+- `EzBaseElement` base class — unchanged; this is all CSS + one shadow-DOM style block.
+
+---
+
+## Execution: Agent Swarm + Worktree Strategy
+
+The user asked for agent-swarms and git worktrees. Because all three major SCSS fixes (A, B, D, E) touch the **same file** (`textfield.scss`), parallel worktrees there would conflict. The practical split is by **file ownership**:
+
+**One GitHub issue, one feature branch, one worktree.** Within that worktree, run two swarm-phase agents **in parallel** on non-overlapping files, then a sequential verification phase:
+
+- **Worktree**: `../atomic-material-js-textfield-fix/` on branch `fix/NNN-textfield-overhaul` (NNN = new issue number).
+- **Swarm phase 1 (parallel)**:
+  - Agent α — rewrites `packages/ui/scss/modules/input/textfield.scss` (Fixes A, B, D, E).
+  - Agent β — patches `packages/ui/ez-textfield/ez-textfield.scss` + `packages/ui/scss/modules/focus-ring.scss` (Fix C).
+  - Agent γ — updates `packages/ui/ez-textfield/ez-textfield.stories.ts` helpers and any affected play selectors (Fix F).
+- **Swarm phase 2 (sequential)**:
+  - Run `pnpm lintfix`, `pnpm build`, and the Storybook test runner in the worktree.
+  - Visually verify in Storybook that focus no longer shifts layout and no double-outline appears.
+- **Merge**: single PR off the branch, closes the new issue + references the two items in `md/issues/ez-textfield-and-general-issues.md`.
+
+**Prerequisite**: create a GitHub issue ("fix(ez-textfield): layout shift, slotted focus ring, select/textarea label positioning") — per `CLAUDE.md`, work cannot start without it.
+
+---
+
+## Verification
+
+End-to-end checks once the branch is built:
+
+1. **Layout shift** — Open Storybook for `OutlinedTextField` and `FilledTextField`. Focus the input; use DevTools Layout Shift tool (or visually confirm). Repeat with `TextareaTextField` and `SelectTextField`. Before fix: visible 2px jump. After: zero shift.
+2. **Slotted focus ring** — Tab into `<ez-textfield>` (custom-element story variants); only the container outline should render, never a second ring on the inner input. Verify via computed-style panel that the `<input>` has `outline: none`.
+3. **Floating label positioning** —
+   - `SelectTextField`: label should be pre-floated (top, small font) from initial render.
+   - `TextareaTextField`: label should sit at the top (not vertically centered against a tall textarea), animate up on focus, and stay up while populated.
+4. **Play functions pass** — `pnpm test` (or the storybook test-runner equivalent used in the repo). All existing assertions should still hold since we are not changing class names or structure, only border technique.
+5. **Lint + build** — `pnpm lintfix && pnpm build` clean.
+6. **Reduced motion** — with `prefers-reduced-motion: reduce` enabled, no transitions fire; state changes are instant but still visually correct.
+7. **Error + disabled states** — `ErrorStates` and disabled variants should continue to render the error color and dimmed appearance (only the border *technique* changed, not the colors).
+
+---
+
+## Decisions confirmed
+
+- `.ez-textfield-border-container` will be **removed entirely**. Box-shadow on `.ez-textfield` itself carries the border for both variants. No wrapper element; ~43 lines of CSS deleted; stories updated to drop the wrapper.
+- Work lands as **one GitHub issue, one feature branch, one PR**. Agent swarm runs inside a single worktree, split by file ownership (α = `textfield.scss`, β = `ez-textfield.scss` + `focus-ring.scss`, γ = stories).

--- a/packages/ui/ez-textfield/ez-textfield.scss
+++ b/packages/ui/ez-textfield/ez-textfield.scss
@@ -17,3 +17,16 @@
 :host [part='center'] {
   flex: 1;
 }
+
+/* Suppress native focus outlines on slotted controls — the <ez-textfield>
+   host (in light DOM, matched by focus-ring.scss) is the sole focus
+   indicator. Slotted elements live outside the shadow DOM, so this
+   ::slotted() rule is the only way to reach them from shadow styles. */
+:host ::slotted(input:focus),
+:host ::slotted(input:focus-visible),
+:host ::slotted(select:focus),
+:host ::slotted(select:focus-visible),
+:host ::slotted(textarea:focus),
+:host ::slotted(textarea:focus-visible) {
+  outline: none;
+}

--- a/packages/ui/ez-textfield/ez-textfield.stories.ts
+++ b/packages/ui/ez-textfield/ez-textfield.stories.ts
@@ -84,28 +84,10 @@ function renderTextField({
             <span class="md-icon">${trailingIcon}</span>
           </div>`
         : ''}
-    `;
-
-  /* Outlined variant: wrap with border-container to prevent layout shift on focus */
-  if (variant === 'ez-outlined') {
-    const containerClasses = [
-      'ez-textfield-border-container',
-      'ez-outlined',
-      stateFlags,
-    ]
+    `,
+    rootClasses = ['ez-textfield', variant, stateFlags]
       .filter(Boolean)
       .join(' ');
-
-    return html`
-      <div class="${containerClasses}">
-        <div class="ez-textfield">${inner}</div>
-      </div>
-    `;
-  }
-
-  const rootClasses = ['ez-textfield', variant, stateFlags]
-    .filter(Boolean)
-    .join(' ');
 
   return html`<div class="${rootClasses}">${inner}</div>`;
 }
@@ -173,27 +155,10 @@ function renderSelectField({
             <span class="md-icon">${trailingIcon}</span>
           </div>`
         : ''}
-    `;
-
-  if (variant === 'ez-outlined') {
-    const containerClasses = [
-      'ez-textfield-border-container',
-      'ez-outlined',
-      stateFlags,
-    ]
+    `,
+    rootClasses = ['ez-textfield', variant, stateFlags]
       .filter(Boolean)
       .join(' ');
-
-    return html`
-      <div class="${containerClasses}">
-        <div class="ez-textfield">${inner}</div>
-      </div>
-    `;
-  }
-
-  const rootClasses = ['ez-textfield', variant, stateFlags]
-    .filter(Boolean)
-    .join(' ');
 
   return html`<div class="${rootClasses}">${inner}</div>`;
 }
@@ -244,27 +209,10 @@ function renderTextareaField({
         ></textarea>
         <label class="ez-textfield-label" for="${id}">${label}</label>
       </div>
-    `;
-
-  if (variant === 'ez-outlined') {
-    const containerClasses = [
-      'ez-textfield-border-container',
-      'ez-outlined',
-      stateFlags,
-    ]
+    `,
+    rootClasses = ['ez-textfield', variant, stateFlags]
       .filter(Boolean)
       .join(' ');
-
-    return html`
-      <div class="${containerClasses}">
-        <div class="ez-textfield">${inner}</div>
-      </div>
-    `;
-  }
-
-  const rootClasses = ['ez-textfield', variant, stateFlags]
-    .filter(Boolean)
-    .join(' ');
 
   return html`<div class="${rootClasses}">${inner}</div>`;
 }

--- a/packages/ui/scss/modules/focus-ring.scss
+++ b/packages/ui/scss/modules/focus-ring.scss
@@ -1,10 +1,10 @@
-:is(.ez-textfield):has(
+:is(.ez-textfield, ez-textfield):has(
   :is(input, select, textarea):focus-visible
 ),
 :is(
-  .ez-radio, .ez-checkbox, .ez-textfield, button,
+  .ez-radio, .ez-checkbox, .ez-textfield, ez-textfield, button,
   .ez-btn, .ez-button, ez-button,
-  :is(:not(.ez-textfield) > :is(select, textarea, input))
+  :is(:not(.ez-textfield, ez-textfield) > :is(select, textarea, input))
 ):focus-visible {
   outline: 3px solid var(--ez-focus-ring-color);
   outline-offset: 2px;

--- a/packages/ui/scss/modules/input/textfield.scss
+++ b/packages/ui/scss/modules/input/textfield.scss
@@ -8,33 +8,29 @@
  * number, password, search, tel, time, url, week.
  * Also supports select and textarea elements.
  *
+ * Border strategy: both variants render their outline / active indicator with
+ * an inset `box-shadow` rather than a real `border`. The 1px → 3px focus
+ * transition is therefore purely visual and never triggers a layout shift.
+ *
  * Two usage approaches:
  *
- * 1. Flat DOM — use .ez-textfield class directly on/around a control:
+ * 1. Flat DOM — .ez-textfield wraps a bare control:
  *    <div class="ez-textfield ez-filled">
  *      <label for="…">Label</label>
  *      <input id="…" type="text" placeholder=" " />
  *    </div>
  *
- * 2. Structured — use .ez-textfield with named child regions:
- *    .ez-textfield[.ez-filled|.ez-outlined]
- *      .ez-textfield-leading   (optional)
- *      .ez-textfield-center
+ * 2. Structured — .ez-textfield with named child regions:
+ *    <div class="ez-textfield[.ez-filled|.ez-outlined]">
+ *      <div class="ez-textfield-leading">…</div>   (optional)
+ *      <div class="ez-textfield-center">
  *        :where(input:not([type="hidden"]), select, textarea)
- *        .ez-textfield-label   (optional)
- *      .ez-textfield-trailing  (optional)
+ *        <span class="ez-textfield-label">…</span>  (optional)
+ *      </div>
+ *      <div class="ez-textfield-trailing">…</div>  (optional)
+ *    </div>
  *
- * 3. Outlined structured — use .ez-textfield-border-container to prevent
- *    layout shift when the focus border-width changes from 1px to 3px:
- *    .ez-textfield-border-container.ez-outlined[state-classes]
- *      .ez-textfield
- *        .ez-textfield-leading   (optional)
- *        .ez-textfield-center
- *          :where(input:not([type="hidden"]), select, textarea)
- *          .ez-textfield-label   (optional)
- *        .ez-textfield-trailing  (optional)
- *
- * Help, messages, supported text, etc., are handled by `.ez-field`/`ez-field`.
+ * Help, messages, supporting text, etc. are handled by `.ez-field` / `ez-field`.
  */
 @import "../../component-prelude";
 
@@ -43,7 +39,7 @@
  *
  * Token priority: --md-color-* > --md-sys-color-* > --ez-* > system
  * ======================================================= */
-:where(.ez-textfield, .ez-textfield-border-container) {
+:where(.ez-textfield) {
   /* Typography — body-large */
   --_tf-font-size: var(--md-sys-typescale-body-large-size, 1rem);
   --_tf-font-family: var(--md-sys-typescale-body-large-font, inherit), sans-serif;
@@ -61,6 +57,7 @@
   --_tf-label-padding: calc(var(--_tf-font-size) / 3);
   --_tf-border-radius: var(--md-sys-shape-corner-extra-small, var(--ez-border-radius, 0.25rem));
   --_tf-border-width: var(--ez-input-border-width, var(--ez-1px, 1px));
+  --_tf-border-width-focus: 3px;
 
   /* Motion */
   --_tf-speed: var(--md-sys-motion-duration-short4, var(--ez-input-speed, 200ms));
@@ -101,6 +98,9 @@
 
 /* =======================================================
  * State-based property reassignment
+ *
+ * Width changes here flow through the box-shadow rules below, which do not
+ * participate in layout — so focus / hover never shifts the page.
  * ======================================================= */
 
 /* Hover (not focused) — filled: indicator → on-surface */
@@ -109,30 +109,29 @@
 }
 
 /* Hover (not focused) — outlined: outline + label → on-surface */
-:where(.ez-textfield, .ez-textfield-border-container).ez-outlined:not(:focus-within):hover {
+:where(.ez-textfield).ez-outlined:not(:focus-within):hover {
   --_tf-outline-color: var(--_tf-text-color);
   --_tf-label-color: var(--_tf-text-color);
 }
 
 /* Focus — label → focus-color (primary / --md-color-theme) */
-:where(.ez-textfield, .ez-textfield-border-container):where(:focus-within) {
+:where(.ez-textfield):where(:focus-within) {
   --_tf-label-color: var(--_tf-focus-color);
 }
 
-/* Focus — filled: indicator → focus-color, 3px per spec */
+/* Focus — filled: indicator → focus-color, widen to spec thickness */
 :where(.ez-textfield).ez-filled:where(:focus-within) {
   --_tf-indicator-color: var(--_tf-focus-color);
-  --_tf-indicator-width: 3px;
+  --_tf-indicator-width: var(--_tf-border-width-focus);
 }
 
-/* Focus — outlined: outline → focus-color, 3px per spec */
+/* Focus — outlined: outline → focus-color (width handled in box-shadow rule) */
 :where(.ez-textfield).ez-outlined:where(:focus-within) {
   --_tf-outline-color: var(--_tf-focus-color);
-  --_tf-border-width: 3px;
 }
 
 /* Error — label, caret, trailing, supporting → error-color */
-:where(.ez-textfield, .ez-textfield-border-container):where(.ez-error, :has(:invalid)) {
+:where(.ez-textfield):where(.ez-error, :has(:invalid)) {
   --_tf-label-color: var(--_tf-error-color);
   --_tf-caret-color: var(--_tf-error-color);
   --_tf-trailing-icon-color: var(--_tf-error-color);
@@ -145,12 +144,12 @@
 }
 
 /* Error — outlined: outline → error-color */
-:where(.ez-textfield, .ez-textfield-border-container).ez-outlined:where(.ez-error, :has(:invalid)) {
+:where(.ez-textfield).ez-outlined:where(.ez-error, :has(:invalid)) {
   --_tf-outline-color: var(--_tf-error-color);
 }
 
 /* Error + Focus — error overrides focus color */
-:where(.ez-textfield, .ez-textfield-border-container):where(.ez-error, :has(:invalid)):focus-within {
+:where(.ez-textfield):where(.ez-error, :has(:invalid)):focus-within {
   --_tf-label-color: var(--_tf-error-color);
   --_tf-caret-color: var(--_tf-error-color);
   --_tf-trailing-icon-color: var(--_tf-error-color);
@@ -161,12 +160,12 @@
   --_tf-indicator-color: var(--_tf-error-color);
 }
 
-:where(.ez-textfield, .ez-textfield-border-container).ez-outlined:where(.ez-error, :has(:invalid)):focus-within {
+:where(.ez-textfield).ez-outlined:where(.ez-error, :has(:invalid)):focus-within {
   --_tf-outline-color: var(--_tf-error-color);
 }
 
 /* Error + Hover (not focused) — label, trailing → error-hover-color */
-:where(.ez-textfield, .ez-textfield-border-container):where(.ez-error, :has(:invalid)):not(:focus-within):hover {
+:where(.ez-textfield):where(.ez-error, :has(:invalid)):not(:focus-within):hover {
   --_tf-label-color: var(--_tf-error-hover-color);
   --_tf-trailing-icon-color: var(--_tf-error-hover-color);
 }
@@ -175,16 +174,12 @@
   --_tf-indicator-color: var(--_tf-error-hover-color);
 }
 
-:where(.ez-textfield, .ez-textfield-border-container).ez-outlined:where(.ez-error, :has(:invalid)):not(:focus-within):hover {
+:where(.ez-textfield).ez-outlined:where(.ez-error, :has(:invalid)):not(:focus-within):hover {
   --_tf-outline-color: var(--_tf-error-hover-color);
 }
 
 /* =======================================================
- * Flat-DOM textfield styles
- *
- * For use when .ez-textfield wraps a bare
- * input with optional > label, .ez-textfield-leading,
- * .ez-textfield-trailing children.
+ * Base textfield
  * ======================================================= */
 
 /* Layout direction */
@@ -196,77 +191,6 @@ html[dir="rtl"] :where(.ez-textfield) {
   flex-flow: column nowrap;
 }
 
-/* Filled variant (flat DOM) */
-:where(.ez-textfield).ez-filled {
-  position: relative;
-  background: var(--_tf-container-color);
-  border: none;
-  border-bottom: var(--_tf-indicator-width) solid var(--_tf-indicator-color);
-  border-radius: var(--_tf-border-radius) var(--_tf-border-radius) 0 0;
-  min-height: 56px;
-}
-
-/* Outlined focus enhancement (flat DOM) */
-:where(.ez-textfield).ez-outlined:has(:focus) {
-  border-width: 3px;
-  border-color: var(--_tf-outline-color);
-}
-
-:where(.ez-textfield).ez-outlined:has(:is(.ez-error, :invalid)) {
-  border-color: var(--_tf-outline-color);
-}
-
-/* Floating label (flat DOM) */
-:where(.ez-textfield).ez-filled > label,
-:where(.ez-textfield).ez-outlined > label {
-  position: absolute;
-  top: 50%;
-  left: var(--ez-input-padding-inline, var(--ez-6px));
-  transform: translateY(-50%);
-  font-size: var(--_tf-font-size);
-  color: var(--_tf-label-color);
-  pointer-events: none;
-  transition: transform var(--_tf-speed) var(--_tf-easing),
-              font-size var(--_tf-speed) var(--_tf-easing),
-              top var(--_tf-speed) var(--_tf-easing);
-}
-
-:where(.ez-textfield).ez-filled:has(:focus, :not(:placeholder-shown)) > label {
-  top: 8px;
-  transform: translateY(0);
-  font-size: var(--_tf-font-size-small);
-  color: var(--_tf-label-color);
-}
-
-:where(.ez-textfield).ez-outlined:has(:focus, :not(:placeholder-shown)) > label {
-  top: 0;
-  transform: translateY(-50%);
-  font-size: var(--_tf-font-size-small);
-  color: var(--_tf-label-color);
-  background: var(--_tf-surface-color);
-  padding-inline: 4px;
-}
-
-/* Leading/trailing icons (flat DOM) */
-:where(.ez-textfield) > .ez-textfield-leading {
-  display: flex;
-  align-items: center;
-  padding-inline-start: var(--md-sys-spacing-3, 0.75rem);
-  color: var(--_tf-icon-color);
-}
-
-:where(.ez-textfield) > .ez-textfield-trailing {
-  display: flex;
-  align-items: center;
-  padding-inline-end: var(--md-sys-spacing-3, 0.75rem);
-  color: var(--_tf-trailing-icon-color);
-}
-
-/* =======================================================
- * Structured textfield styles (.ez-textfield)
- * ======================================================= */
-
-/* Base */
 :where(.ez-textfield) {
   position: relative;
   display: inline-flex;
@@ -278,17 +202,17 @@ html[dir="rtl"] :where(.ez-textfield) {
   @extend %md-typescale-body-large;
 
   color: var(--_tf-text-color);
-  transition: border-color var(--_tf-speed) var(--_tf-easing);
   background: transparent;
   border-radius: var(--_tf-border-radius);
   gap: var(--_tf-padding);
+  transition: box-shadow var(--_tf-speed) var(--_tf-easing);
 
   &, * {
     box-sizing: border-box;
   }
 }
 
-/* Leading / Trailing icon areas (24dp per spec) */
+/* Leading / trailing icon areas (24dp per spec) */
 :where(.ez-textfield) :where(.ez-textfield-leading),
 :where(.ez-textfield) :where(.ez-textfield-trailing) {
   display: none;
@@ -315,7 +239,7 @@ html[dir="rtl"] :where(.ez-textfield) {
   gap: var(--_tf-label-padding);
 }
 
-/* Input element */
+/* Interactive control (input / select / textarea) */
 :where(.ez-textfield) :where(input:not([type="hidden"]), select, textarea) {
   position: relative;
   display: inline-block;
@@ -325,31 +249,28 @@ html[dir="rtl"] :where(.ez-textfield) {
 
   line-height: var(--_tf-font-size);
   background: transparent;
-  transition: opacity var(--_tf-speed) var(--_tf-easing);
   color: var(--_tf-text-color);
   caret-color: var(--_tf-caret-color);
   border: none;
   border-radius: var(--_tf-border-radius);
   width: 100%;
-  opacity: 0;
 }
 
 :where(.ez-textfield) :where(input:not([type="hidden"]), select, textarea)::placeholder {
   color: var(--_tf-placeholder-color);
 }
 
-:where(.ez-textfield) :where(input:not([type="hidden"]), select, textarea):focus {
-  outline: none;
-  opacity: 1;
-}
-
-/* Suppress focus ring on interactive controls inside the textfield — the
-   textfield container itself manages the visual focus indicator. */
+/* Suppress native focus ring on the inner control — the .ez-textfield
+   container itself renders the visible focus indicator (see focus-ring.scss). */
+:where(.ez-textfield) :where(input:not([type="hidden"]), select, textarea):focus,
 :where(.ez-textfield) :where(input:not([type="hidden"]), select, textarea):focus-visible {
   outline: none;
 }
 
-/* Floating label (.ez-textfield-label) */
+/* =======================================================
+ * Floating label (structured — .ez-textfield-label)
+ * ======================================================= */
+
 :where(.ez-textfield) :where(.ez-textfield-label) {
   position: absolute;
   display: none;
@@ -359,8 +280,6 @@ html[dir="rtl"] :where(.ez-textfield) {
   user-select: none;
   cursor: text;
   transition: transform var(--_tf-speed) var(--_tf-easing),
-              background var(--_tf-speed) var(--_tf-easing),
-              border-color var(--_tf-speed) var(--_tf-easing),
               color var(--_tf-speed) var(--_tf-easing);
   border-radius: var(--_tf-border-radius);
   transform-origin: top left;
@@ -373,24 +292,36 @@ html[dir="rtl"] :where(.ez-textfield) {
   background: none;
 }
 
-:where(.ez-textfield) :where(.ez-textfield-label):hover {
-  cursor: text;
-}
-
-/* Required indicator */
+/* Required asterisk */
 :where(.ez-textfield):where([required], .ez-required, :has(:required)) :where(.ez-textfield-label)::before {
   content: "*";
   color: var(--_tf-error-color);
 }
 
-/* Focus-within — show input + activate label */
-:where(.ez-textfield):focus-within :where(input:not([type="hidden"]), select, textarea) {
-  opacity: 1;
-}
-
+/* Float label on focus */
 :where(.ez-textfield):focus-within :where(.ez-textfield-label) {
   transform: var(--_tf-label-active-transform);
   color: var(--_tf-label-color);
+}
+
+/* Float label when input has a value (populated) */
+:where(.ez-textfield):has(input:not([type="hidden"], :placeholder-shown)) :where(.ez-textfield-label) {
+  transform: var(--_tf-label-active-transform);
+}
+
+/* Select has no placeholder concept — label is always floated */
+:where(.ez-textfield):has(select) :where(.ez-textfield-label) {
+  transform: var(--_tf-label-active-transform);
+}
+
+/* Textarea — top-align the label in its resting position (not vertically
+   centered against a tall multi-line control); float on focus or populated */
+:where(.ez-textfield):has(textarea) :where(.ez-textfield-label) {
+  top: var(--_tf-padding);
+}
+
+:where(.ez-textfield):has(textarea:not(:placeholder-shown)) :where(.ez-textfield-label) {
+  transform: var(--_tf-label-active-transform);
 }
 
 /* Hover (not focused) — input color */
@@ -398,42 +329,102 @@ html[dir="rtl"] :where(.ez-textfield) {
   color: var(--_tf-text-color);
 }
 
-/* Filled variant (.ez-filled) */
+/* =======================================================
+ * Floating label (flat DOM — direct `> label`)
+ * ======================================================= */
+
+:where(.ez-textfield).ez-filled > label,
+:where(.ez-textfield).ez-outlined > label {
+  position: absolute;
+  top: 50%;
+  left: var(--ez-input-padding-inline, var(--ez-6px));
+  transform: translateY(-50%);
+  font-size: var(--_tf-font-size);
+  color: var(--_tf-label-color);
+  pointer-events: none;
+  transition: transform var(--_tf-speed) var(--_tf-easing),
+              font-size var(--_tf-speed) var(--_tf-easing),
+              top var(--_tf-speed) var(--_tf-easing);
+}
+
+/* Textarea: label starts at the top, not vertically centered */
+:where(.ez-textfield).ez-filled:has(textarea) > label,
+:where(.ez-textfield).ez-outlined:has(textarea) > label {
+  top: var(--_tf-padding);
+  transform: translateY(0);
+}
+
+/* Filled — float label on focus / populated */
+:where(.ez-textfield).ez-filled:has(:focus, :not(:placeholder-shown)) > label,
+:where(.ez-textfield).ez-filled:has(select) > label {
+  top: 8px;
+  transform: translateY(0);
+  font-size: var(--_tf-font-size-small);
+}
+
+/* Outlined — float label on focus / populated (with notch background) */
+:where(.ez-textfield).ez-outlined:has(:focus, :not(:placeholder-shown)) > label,
+:where(.ez-textfield).ez-outlined:has(select) > label {
+  top: 0;
+  transform: translateY(-50%);
+  font-size: var(--_tf-font-size-small);
+  background: var(--_tf-surface-color);
+  padding-inline: 4px;
+}
+
+/* =======================================================
+ * Variants — borders rendered via inset box-shadow (no layout shift)
+ * ======================================================= */
+
+/* Filled — bottom active indicator */
 :where(.ez-textfield).ez-filled {
   background: var(--_tf-container-color);
-  border-bottom: var(--_tf-indicator-width) solid var(--_tf-indicator-color);
+  border: none;
+  box-shadow: inset 0 calc(-1 * var(--_tf-indicator-width)) 0 0 var(--_tf-indicator-color);
   border-radius: var(--_tf-border-radius) var(--_tf-border-radius) 0 0;
+  min-height: 56px;
 }
 
-:where(.ez-textfield).ez-filled:focus-within {
-  border-bottom-color: var(--_tf-indicator-color);
-}
-
-/* Outlined variant (.ez-outlined) */
+/* Outlined — full outline */
 :where(.ez-textfield).ez-outlined {
-  border: var(--_tf-border-width) solid var(--_tf-outline-color);
+  border: none;
+  box-shadow: inset 0 0 0 var(--_tf-border-width) var(--_tf-outline-color);
 }
 
 :where(.ez-textfield).ez-outlined:focus-within {
-  border-color: var(--_tf-outline-color);
+  box-shadow: inset 0 0 0 var(--_tf-border-width-focus) var(--_tf-outline-color);
 }
 
 /* Outlined active label: surface background for notch effect */
-:where(.ez-textfield).ez-outlined:has(:where(input:not([type="hidden"]), select, textarea):not(:placeholder-shown)) :where(.ez-textfield-label),
+:where(.ez-textfield).ez-outlined:has(input:not([type="hidden"], :placeholder-shown)) :where(.ez-textfield-label),
+:where(.ez-textfield).ez-outlined:has(select) :where(.ez-textfield-label),
+:where(.ez-textfield).ez-outlined:has(textarea:not(:placeholder-shown)) :where(.ez-textfield-label),
 :where(.ez-textfield).ez-outlined:focus-within :where(.ez-textfield-label) {
   background: var(--_tf-surface-color);
 }
 
-/* Error + Focus — structural borders */
-:where(.ez-textfield).ez-filled:where(.ez-error, :has(:invalid)):focus-within {
-  border-bottom-color: var(--_tf-indicator-color);
+/* =======================================================
+ * Leading / trailing icons (flat DOM layout)
+ * ======================================================= */
+
+:where(.ez-textfield) > .ez-textfield-leading {
+  display: flex;
+  align-items: center;
+  padding-inline-start: var(--md-sys-spacing-3, 0.75rem);
+  color: var(--_tf-icon-color);
 }
 
-:where(.ez-textfield).ez-outlined:where(.ez-error, :has(:invalid)):focus-within {
-  border-color: var(--_tf-outline-color);
+:where(.ez-textfield) > .ez-textfield-trailing {
+  display: flex;
+  align-items: center;
+  padding-inline-end: var(--md-sys-spacing-3, 0.75rem);
+  color: var(--_tf-trailing-icon-color);
 }
 
-/* Disabled (per-element color/opacity per spec) */
+/* =======================================================
+ * Disabled
+ * ======================================================= */
+
 :where(.ez-textfield):where([disabled], .ez-disabled, :has(:disabled)) {
   pointer-events: none;
   cursor: not-allowed;
@@ -447,29 +438,23 @@ html[dir="rtl"] :where(.ez-textfield) {
   opacity: var(--_tf-disabled-content-opacity);
 }
 
-/* Filled disabled: container + active indicator */
+/* Filled disabled — container + active indicator */
 :where(.ez-textfield).ez-filled:where([disabled], .ez-disabled, :has(:disabled)) {
   background-color: var(--_tf-disabled-color);
-  border-bottom-color: var(--_tf-disabled-color);
+  box-shadow: inset 0 calc(-1 * var(--_tf-border-width)) 0 0 var(--_tf-disabled-color);
   opacity: 0.04;
 }
 
-/* Outlined disabled: outline */
+/* Outlined disabled — outline */
 :where(.ez-textfield).ez-outlined:where([disabled], .ez-disabled, :has(:disabled)) {
-  border-color: var(--_tf-disabled-color);
+  box-shadow: inset 0 0 0 var(--_tf-border-width) var(--_tf-disabled-color);
   opacity: var(--_tf-disabled-container-opacity);
 }
 
-/* Has-value state */
-:where(.ez-textfield):has(:where(input:not([type="hidden"]), select, textarea):not(:placeholder-shown)) :where(input:not([type="hidden"]), select, textarea) {
-  opacity: 1;
-}
+/* =======================================================
+ * Structural / value-based visibility
+ * ======================================================= */
 
-:where(.ez-textfield):has(:where(input:not([type="hidden"]), select, textarea):not(:placeholder-shown)) :where(.ez-textfield-label) {
-  transform: var(--_tf-label-active-transform);
-}
-
-/* Structural / value-based visibility */
 :where(.ez-textfield):has(.ez-textfield-leading) :where(.ez-textfield-center) {
   margin-left: 0;
 }
@@ -487,10 +472,11 @@ html[dir="rtl"] :where(.ez-textfield) {
   display: inline-block;
 }
 
-/* Fullwidth */
+/* =======================================================
+ * Fullwidth
+ * ======================================================= */
+
 :where(.ez-textfield).ez-fullwidth,
-:where(.ez-textfield-border-container).ez-fullwidth,
-:where(.ez-textfield-border-container).ez-fullwidth > :where(.ez-textfield),
 :where(.ez-textfield).ez-fullwidth :where(.ez-textfield-center),
 :where(.ez-textfield).ez-fullwidth :where(input:not([type="hidden"]), select, textarea) {
   flex-basis: 100%;
@@ -498,80 +484,12 @@ html[dir="rtl"] :where(.ez-textfield) {
 }
 
 /* =======================================================
- * .ez-textfield-border-container — Outlined variant without layout shift
- *
- * Wrapping .ez-textfield with .ez-textfield-border-container.ez-outlined
- * prevents the layout shift that occurs when the focus border-width changes
- * from 1px to 3px.
- * The container uses an inset box-shadow for the default 1px visual
- * border (no layout effect).  The inner .ez-textfield always carries a
- * 3px solid transparent border that becomes colored on focus — so only
- * the color changes, never the width.
- *
- * Usage:
- *   <div class="ez-textfield-border-container ez-outlined [ez-error] [ez-disabled]">
- *     <div class="ez-textfield">
- *       <div class="ez-textfield-center">…</div>
- *     </div>
- *   </div>
- * ======================================================= */
-
-:where(.ez-textfield-border-container) {
-  display: inline-flex;
-  border-radius: var(--_tf-border-radius);
-
-  &, * {
-    box-sizing: border-box;
-  }
-}
-
-/* Outlined border container — default 1px inset box-shadow (no layout effect) */
-:where(.ez-textfield-border-container).ez-outlined {
-  box-shadow: inset 0 0 0 var(--_tf-border-width) var(--_tf-outline-color);
-  transition: box-shadow var(--_tf-speed) var(--_tf-easing);
-}
-
-/* On focus: hide the container shadow — inner textfield border takes over */
-:where(.ez-textfield-border-container).ez-outlined:focus-within {
-  box-shadow: none;
-}
-
-/* Disabled: dim container shadow */
-:where(.ez-textfield-border-container).ez-outlined:where([disabled], .ez-disabled, :has(:disabled)) {
-  box-shadow: inset 0 0 0 var(--_tf-border-width) var(--_tf-disabled-color);
-  opacity: var(--_tf-disabled-container-opacity);
-  pointer-events: none;
-  cursor: not-allowed;
-}
-
-/* Inner .ez-textfield inside border container: always 3px border, initially transparent */
-:where(.ez-textfield-border-container).ez-outlined > :where(.ez-textfield) {
-  border: 3px solid transparent;
-  transition: border-color var(--_tf-speed) var(--_tf-easing);
-}
-
-/* On focus: inner border becomes visible (color only, no width change → no layout shift) */
-:where(.ez-textfield-border-container).ez-outlined:focus-within > :where(.ez-textfield) {
-  border-color: var(--_tf-focus-color);
-}
-
-/* Error: inner border shows error color on focus */
-:where(.ez-textfield-border-container).ez-outlined:where(.ez-error, :has(:invalid)):focus-within > :where(.ez-textfield) {
-  border-color: var(--_tf-error-color);
-}
-
-/* =======================================================
  * Reduced motion
  * ======================================================= */
 @media (prefers-reduced-motion: reduce) {
-  :where(.ez-textfield).ez-filled > label,
-  :where(.ez-textfield).ez-outlined > label {
-    transition: none;
-  }
-
   :where(.ez-textfield),
-  :where(.ez-textfield-border-container),
-  :where(.ez-textfield-border-container) > :where(.ez-textfield),
+  :where(.ez-textfield).ez-filled > label,
+  :where(.ez-textfield).ez-outlined > label,
   :where(.ez-textfield) :where(.ez-textfield-label),
   :where(.ez-textfield) :where(input:not([type="hidden"]), select, textarea),
   :where(.ez-textfield) :where(.ez-textfield-leading),


### PR DESCRIPTION
Closes #107. Also resolves items 1 & 2 in `md/issues/ez-textfield-and-general-issues.md`.

## Summary
- Replace width-changing borders on `.ez-filled` and `.ez-outlined` with inset `box-shadow`, eliminating the 2px focus layout shift and removing the unused `.ez-textfield-border-container` workaround (~43 SCSS lines deleted).
- Reach into light-DOM slotted controls from the shadow DOM via `::slotted()` rules in `ez-textfield.scss`, and extend `focus-ring.scss` to exclude `ez-textfield` custom-element descendants — so the host alone renders the focus indicator instead of producing a double outline.
- Fix floating-label positioning for `:has(select)` (always-floated — selects have no placeholder concept) and `:has(textarea)` (top-aligned in the resting position; no longer vertically centered against a tall control).
- Remove the `opacity: 0 → 1` fade-in on slotted inputs and trim the label transition list to `transform, color` only.

Plan: [`md/plans/fix-ez-textfield-overhaul.md`](../blob/fix/107-textfield-overhaul/md/plans/fix-ez-textfield-overhaul.md).

## Test plan
- [ ] `pnpm lintfix` clean
- [ ] `pnpm build` green
- [ ] `pnpm test` — all 144 tests pass (including 9 `ez-textfield` stories)
- [ ] In Storybook, focus outlined and filled textfields: zero layout shift
- [ ] Tab into `<ez-textfield>` with an inner control: only the container outline renders (no double ring on the input)
- [ ] `SelectTextField` story: label floats on initial render
- [ ] `TextareaTextField` story: label sits at the top of the resting control and animates up on focus / when populated
- [ ] Error + disabled states still render correct colors and dimmed appearance

🤖 Generated with [Claude Code](https://claude.com/claude-code)