### PR TITLE
fix(ez-tabs): #117 remove double active indicator on custom element

### DIFF
--- a/packages/ui/scss/modules/tabs.scss
+++ b/packages/ui/scss/modules/tabs.scss
@@ -261,10 +261,20 @@ $tall-tab-padding-block: calc(#{$tab-padding} - (#{$font-and-line-height-diff} /
 
 /* ─── CSS-only fallback: active indicator via pseudo-element ──────────────── */
 
-/* When .ez-tabs__indicator element is not present, use tab ::after pseudo */
+/*
+ * When a `.ez-tabs__indicator` element is not present, paint the active
+ * indicator via a tab `::after` pseudo-element instead.
+ *
+ * The custom-element tag is gated behind `:not(:defined)` on purpose: an
+ * upgraded `<ez-tabs>` renders its own `.ez-tabs__indicator` inside its
+ * shadow root, but `:has()` cannot pierce the shadow boundary to see it — so
+ * without this guard the fallback would paint a SECOND indicator in the light
+ * DOM (this stylesheet is bundled globally). Class-based usage and not-yet
+ * -upgraded custom elements still get the fallback.
+ */
 
-:where(.ez-tabs, ez-tabs):not(:has(.ez-tabs__indicator))
-  > :where(.ez-tab.ez-active, ez-tab[active])::after {
+:where(.ez-tabs, ez-tabs:not(:defined)):not(:has(.ez-tabs__indicator))
+  > :where(.ez-tab.ez-active, ez-tab:not(:defined)[active])::after {
   content: "";
   position: absolute;
   bottom: -1px;
@@ -275,8 +285,8 @@ $tall-tab-padding-block: calc(#{$tab-padding} - (#{$font-and-line-height-diff} /
   border-radius: var(--_tabs-active-indicator-shape);
 }
 
-:where(.ez-tabs.ez-secondary, ez-tabs[variant="secondary"]):not(:has(.ez-tabs__indicator))
-  > :where(.ez-tab.ez-active, ez-tab[active])::after {
+:where(.ez-tabs.ez-secondary, ez-tabs:not(:defined)[variant="secondary"]):not(:has(.ez-tabs__indicator))
+  > :where(.ez-tab.ez-active, ez-tab:not(:defined)[active])::after {
   left: 0;
   right: 0;
   height: 2px;


### PR DESCRIPTION
Closes #117

## Problem

The `ez-tabs` custom element rendered **two** active-tab indicators at once (visible in the **Custom Elements/Tabs** Storybook stories).

`tabs.scss` has two indicator mechanisms:
1. A JS-driven `<div class="ez-tabs__indicator">` rendered inside the element's **shadow root**.
2. A CSS `::after` fallback for "when `.ez-tabs__indicator` is not present".

Because `tabs.scss` is bundled into the global light-DOM stylesheet (`scss/modules/index.scss` → `.storybook/preview.ts`), the fallback selector matched the `ez-tabs` tag in the light DOM. Its `:not(:has(.ez-tabs__indicator))` guard couldn't suppress it because **`:has()` does not cross the shadow boundary** and can't see the indicator inside the shadow root — so a second bar was painted on the active tab.

## Fix

Gate the custom-element tag selectors in the fallback behind `:not(:defined)`. Once `<ez-tabs>` upgrades it stops matching, so the `::after` fallback no longer fires (the element already renders its own indicator). Class-based CSS-only usage (`.ez-tabs` / `.ez-tab.ez-active`) and not-yet-upgraded custom elements keep the fallback, preserving progressive enhancement.

## Verification

- [x] `tabs.scss` compiles (dart-sass).
- [ ] Confirm a single indicator in **Custom Elements/Tabs** (primary + secondary) stories.
- [ ] Confirm **CSS Components/Tabs** stories still show one indicator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)