### PR TITLE
feat(ez-tab): #119 expose ARIA semantics on host via ElementInternals

### DIFF
--- a/packages/ui/ez-tab/ez-tab.ts
+++ b/packages/ui/ez-tab/ez-tab.ts
@@ -1,4 +1,10 @@
-import { html, type CSSResultGroup, unsafeCSS, type TemplateResult } from 'lit';
+import {
+  html,
+  type CSSResultGroup,
+  unsafeCSS,
+  type TemplateResult,
+  type PropertyValues,
+} from 'lit';
 
 import { EzBaseElement } from '../ez-base/ez-base.js';
 import '../ez-ripple/index.js';
@@ -14,6 +20,14 @@ export const EzTabName = 'ez-tab';
 export class EzTabElement extends EzBaseElement {
   static localName = EzTabName;
 
+  // Delegate focus into the inner focusable node so the roving-tabindex
+  // focus management driven by `ez-tabs` (which calls `tab.focus()` on the
+  // host) actually lands on the tab.
+  static override shadowRootOptions: ShadowRootInit = {
+    ...EzBaseElement.shadowRootOptions,
+    delegatesFocus: true,
+  };
+
   static override styles: CSSResultGroup = [
     EzBaseElement.styles,
     tabsStyles,
@@ -27,17 +41,32 @@ export class EzTabElement extends EzBaseElement {
 
   declare active: boolean;
 
+  #internals: ElementInternals;
+
   constructor() {
     super();
     this.active = false;
+
+    // Expose ARIA semantics on the host element itself (not the inner shadow
+    // DOM node) so the `tablist` -> `tab` relationship stays intact in the
+    // accessibility tree.
+    this.#internals = this.attachInternals();
+    this.#internals.role = 'tab';
+    this.#internals.ariaSelected = 'false';
+  }
+
+  override willUpdate(changedProperties: PropertyValues): void {
+    super.willUpdate(changedProperties);
+
+    if (changedProperties.has('active')) {
+      this.#internals.ariaSelected = this.active ? 'true' : 'false';
+    }
   }
 
   render(): TemplateResult {
     return html`
       <div
         class="ez-tab ${this.active ? 'ez-active' : ''}"
-        role="tab"
-        aria-selected="${this.active ? 'true' : 'false'}"
         tabindex="${this.active ? '0' : '-1'}"
       >
         <ez-ripple></ez-ripple>

--- a/packages/ui/ez-tabs/ez-tabs.stories.ts
+++ b/packages/ui/ez-tabs/ez-tabs.stories.ts
@@ -32,13 +32,36 @@ export const PrimaryLabelOnly: Story = {
 
     await expect(tabs).toBeInTheDocument();
 
-    const tabItems = tabs?.querySelectorAll('ez-tab');
+    const tabItems = Array.from(
+      tabs?.querySelectorAll<HTMLElement>('ez-tab') ?? []
+    );
 
-    await expect(tabItems?.length).toBe(3);
+    await expect(tabItems.length).toBe(3);
 
     const active = tabs?.querySelector('ez-tab[active]');
 
     await expect(active).toBeInTheDocument();
+
+    // Arrow-key navigation moves the active state AND focus to the next tab.
+    // Focus moving onto the host relies on the tab delegating focus into its
+    // inner focusable node (`delegatesFocus`); ARIA semantics (role/selected)
+    // live on the host via ElementInternals.
+    tabItems[0]?.focus();
+
+    tabs?.dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true })
+    );
+
+    await Promise.all(
+      tabItems.map(
+        t =>
+          (t as unknown as { updateComplete: Promise<boolean> }).updateComplete
+      )
+    );
+
+    await expect(tabItems[1]?.hasAttribute('active')).toBe(true);
+    await expect(tabItems[0]?.hasAttribute('active')).toBe(false);
+    await expect(document.activeElement).toBe(tabItems[1]);
   },
 };
 

--- a/packages/ui/ez-tabs/ez-tabs.ts
+++ b/packages/ui/ez-tabs/ez-tabs.ts
@@ -39,9 +39,18 @@ export class EzTabsElement extends EzBaseElement {
 
   declare variant: EzTabsVariant | '';
 
+  #internals: ElementInternals;
+
   constructor() {
     super();
     this.variant = 'primary';
+
+    // Expose the `tablist` role on the host element itself (matching
+    // `ez-tab`, which carries `role=tab` via ElementInternals). The inner
+    // wrapper is marked presentational in `render()` so the slotted tabs
+    // flatten in as direct children of the tablist in the accessibility tree.
+    this.#internals = this.attachInternals();
+    this.#internals.role = 'tablist';
   }
 
   #resizeObserver: ResizeObserver | null = null;
@@ -191,8 +200,8 @@ export class EzTabsElement extends EzBaseElement {
 
   render(): TemplateResult {
     return html`
-      <div class="ez-tabs ${this.variantClass}" role="tablist">
-        <div class="ez-tabs__indicator"></div>
+      <div class="ez-tabs ${this.variantClass}" role="presentation">
+        <div class="ez-tabs__indicator" aria-hidden="true"></div>
         <slot @slotchange=${this.#onSlotChange}></slot>
       </div>
     `;


### PR DESCRIPTION
Closes #119

## Problem

`ez-tab` and `ez-tabs` set their ARIA roles/state on **inner shadow-DOM nodes**, not the host elements. In the flattened accessibility tree this breaks the `tablist` → `tab` relationship:

```
div[role=tablist]        (ez-tabs shadow wrapper)
  └─ ez-tab               (host — no role → generic)
       └─ div[role=tab]   (ez-tab shadow)   ← grandchild of tablist
```

ARIA requires a `tab` to be a child of the `tablist`. The host elements (which are the actual interaction/focus targets) carried no semantics.

## Changes

**`ez-tab`**
- `attachInternals()`; set `role=tab` and mirror `active` → `ariaSelected` (`'true'`/`'false'`) via `willUpdate`.
- `delegatesFocus: true` on the shadow root so `ez-tabs`' roving-tabindex management (which calls `tab.focus()` on the host) actually moves focus into the inner focusable node. **This fixes a latent bug** — `host.focus()` was previously a no-op, so arrow-key navigation never moved focus.
- Roving `tabindex` (0/-1) kept on the inner node; `role`/`aria-selected` removed from it.

**`ez-tabs`**
- `attachInternals()`; set `role=tablist` on the host.
- Inner wrapper marked `role=presentation` so the slotted tabs flatten in as **direct children** of the host tablist (otherwise the wrapper wedges between tablist and tabs).
- Decorative indicator marked `aria-hidden="true"`.

Resulting tree:
```
ez-tabs[role=tablist]                  (host, ElementInternals)
  ├─ ez-tab[role=tab, aria-selected]   (host, ElementInternals)
  └─ ez-tab[role=tab, aria-selected]
```

**Stories**
- `PrimaryLabelOnly` play function now asserts ArrowRight moves both active state and focus to the next tab.

## Notes
- ElementInternals ARIA is exposed to the platform accessibility tree but **not** reflected as DOM attributes, so the hosts won't show literal `role`/`aria-selected` in the inspector — expected behavior. The play test verifies observable behavior (focus/active) instead.
- The CSS-only component (`index.stories.ts`) is unaffected; it authors `role="tablist"`/`role="tab"` directly in markup.

## Verification
- [x] `tsc` typings pass
- [x] eslint + stylelint pass
- [x] `pnpm test` — 138 tests pass (story play functions run in a real browser via `@storybook/addon-vitest` + Playwright)
- [x] `pnpm build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)