### PR TITLE
fix(ez-tabs): #117 gate CSS indicator fallback behind :not(:defined)

### DIFF
--- a/packages/ui/scss/modules/tabs.scss
+++ b/packages/ui/scss/modules/tabs.scss
@@ -261,11 +261,18 @@ $tall-tab-padding-block: calc(#{$tab-padding} - (#{$font-and-line-height-diff} /
 
 /* ─── CSS-only fallback: active indicator via pseudo-element ──────────────── */
 
-/* When .ez-tabs__indicator element is not present, use tab ::after pseudo */
-
-/* Class-based usage keeps the `:has` guard; custom-element usage is gated by
- * `:not(:defined)` since `:has()` cannot see the indicator rendered in the
- * shadow root — once `<ez-tabs>` upgrades it draws its own indicator. */
+/*
+ * When a `.ez-tabs__indicator` element is not present, paint the active
+ * indicator via a tab `::after` pseudo-element instead.
+ *
+ * Class-based usage keeps the `:has(.ez-tabs__indicator)` guard. The
+ * custom-element tag is split out and gated behind `:not(:defined)` on
+ * purpose: an upgraded `<ez-tabs>` renders its own `.ez-tabs__indicator`
+ * inside its shadow root, but `:has()` cannot pierce the shadow boundary to
+ * see it — so without this guard the fallback would paint a SECOND indicator
+ * in the light DOM (this stylesheet is bundled globally). Not-yet-upgraded
+ * custom elements still get the fallback, preserving progressive enhancement.
+ */
 :where(.ez-tabs):not(:has(.ez-tabs__indicator))
   > .ez-tab.ez-active::after,
 ez-tabs:not(:defined) > ez-tab[active]::after {

--- a/packages/ui/scss/modules/tabs.scss
+++ b/packages/ui/scss/modules/tabs.scss
@@ -263,8 +263,12 @@ $tall-tab-padding-block: calc(#{$tab-padding} - (#{$font-and-line-height-diff} /
 
 /* When .ez-tabs__indicator element is not present, use tab ::after pseudo */
 
-:where(.ez-tabs, ez-tabs):not(:has(.ez-tabs__indicator))
-  > :where(.ez-tab.ez-active, ez-tab[active])::after {
+/* Class-based usage keeps the `:has` guard; custom-element usage is gated by
+ * `:not(:defined)` since `:has()` cannot see the indicator rendered in the
+ * shadow root — once `<ez-tabs>` upgrades it draws its own indicator. */
+:where(.ez-tabs):not(:has(.ez-tabs__indicator))
+  > .ez-tab.ez-active::after,
+ez-tabs:not(:defined) > ez-tab[active]::after {
   content: "";
   position: absolute;
   bottom: -1px;
@@ -275,8 +279,9 @@ $tall-tab-padding-block: calc(#{$tab-padding} - (#{$font-and-line-height-diff} /
   border-radius: var(--_tabs-active-indicator-shape);
 }
 
-:where(.ez-tabs.ez-secondary, ez-tabs[variant="secondary"]):not(:has(.ez-tabs__indicator))
-  > :where(.ez-tab.ez-active, ez-tab[active])::after {
+:where(.ez-tabs.ez-secondary):not(:has(.ez-tabs__indicator))
+  > .ez-tab.ez-active::after,
+ez-tabs[variant="secondary"]:not(:defined) > ez-tab[active]::after {
   left: 0;
   right: 0;
   height: 2px;


### PR DESCRIPTION
Closes #117

## Problem

`ez-tabs` rendered **two** active-tab indicators in the **Custom Elements/Tabs** Storybook stories.

## Root cause

`EzTabsElement` uses Lit's default shadow DOM, so the JS-driven `.ez-tabs__indicator` div lives in the element's shadow root. The CSS `::after` fallback in `tabs.scss` matched the light-DOM `ez-tabs` tag, but its `:not(:has(.ez-tabs__indicator))` guard could not see into the shadow root — `:has()` does not cross the shadow boundary — so the fallback painted a second bar on the active tab.

The **CSS Components/Tabs** stories were unaffected because they place `.ez-tabs__indicator` directly in the light DOM, where `:has()` works.

## Fix

Split each fallback rule in `packages/ui/scss/modules/tabs.scss`:

- Class-based CSS-only usage (`.ez-tabs`) keeps the `:has` guard, where it works.
- Custom-element usage (`ez-tabs`) is gated by `:not(:defined)`, so the `::after` fallback only fires before upgrade and stops once `<ez-tabs>` renders its own indicator. The `[active]` attribute selector still matches pre-upgrade elements.

## Acceptance criteria

- [x] Only one active indicator in the Custom Elements/Tabs stories (primary and secondary)
- [x] CSS Components/Tabs stories still render a single indicator
- [x] Build, lint, and tests pass (`pnpm lintfix`, `pnpm test` — 138/138)

🤖 Generated with [Claude Code](https://claude.com/claude-code)