### PR TITLE
refactor(form-control): #115 scope native-control disabled reset to .ez-* classes

### DIFF
--- a/packages/ui/scss/modules/input/form-control.scss
+++ b/packages/ui/scss/modules/input/form-control.scss
@@ -1,11 +1,22 @@
 /**
  * Base form control styles
  *
- * Shared styles for native form controls (input, select, textarea).
- * Component-specific styles live in their own files.
+ * Shared disabled reset for the library's `.ez-*` controls whose class sits on
+ * the native element (checkbox, radio, switch, range, color). Component-specific
+ * styles live in their own files.
+ *
+ * Scoped to `.ez-*` classes rather than bare `input`/`select`/`textarea` so the
+ * reset never leaks onto unwrapped native controls (see #115).
+ *
+ * Not handled here:
+ * - `.ez-textfield` — its disabled block (`textfield.scss`) owns the wrapper's
+ *   `pointer-events`/`cursor` reset via `[disabled]`/`.ez-disabled`/`:has(:disabled)`.
+ * - `pointer-events: none` for any disabled control is also applied globally by
+ *   `fieldset/index.scss :disabled`; the `cursor: not-allowed` here is the
+ *   `.ez-*`-specific addition.
  */
 
-:where(input:not([type="hidden"]), select, textarea) {
+:where(.ez-checkbox, .ez-radio, .ez-switch, .ez-range, .ez-color) {
   &:disabled {
     pointer-events: none;
     cursor: not-allowed;


### PR DESCRIPTION
## Summary

Closes #115.

`form-control.scss` previously applied its disabled reset to **bare native elements**:

```scss
:where(input:not([type="hidden"]), select, textarea) {
  &:disabled { pointer-events: none; cursor: not-allowed; }
}
```

This matched every native `input`/`select`/`textarea` on the page (including controls not part of any `ez-*` component) and overlapped with `fieldset/index.scss :disabled` and `.ez-textfield`'s own disabled block.

Per the project convention that component styling should attach to `.ez-*` control classes, the reset is now scoped to the library's controls whose class sits directly on the native element:

```scss
:where(.ez-checkbox, .ez-radio, .ez-switch, .ez-range, .ez-color) {
  &:disabled { pointer-events: none; cursor: not-allowed; }
}
```

## Notes

- **`.ez-textfield` excluded by design** — its disabled state is a wrapper-level concern already owned by `textfield.scss` (`[disabled]` / `.ez-disabled` / `:has(:disabled)`). Adding it here would duplicate that block, so it's omitted per the issue's de-dup request.
- **No behavior lost** — each of the five listed controls applies its `.ez-*` class directly on the native element, so `:disabled` resolves the same as before for them. The global `pointer-events: none` from `fieldset/index.scss :disabled` continues to cover any disabled control; `cursor: not-allowed` remains the `.ez-*`-specific addition.
- No bare-element disabled styling remains in `form-control.scss`.

## Verification

- `pnpm stylelint` — clean.
- Unit tests — 30/30 pass.
- SCSS compiles (the `form-control` → `component-prelude` → `textfield` import chain transforms without error).

> Note: `pnpm build` and the browser/Storybook e2e suite could not complete **in this git worktree** due to a pre-existing, environment-only issue — rollup's `preserveModulesRoot` derives an invalid relative `output.entryFileNames` from the nested `.claude/worktrees/…` path. This reproduces identically with the change reverted (`git stash`), so it is unrelated to this CSS change. Both should run normally on a top-level checkout / CI.