### PR TITLE
feat(ez-views): #121 add generic view-stack primitive (ez-views / ez-view)

### DIFF
--- a/packages/ui-next/ez-view/index.ts
+++ b/packages/ui-next/ez-view/index.ts
@@ -1,0 +1,12 @@
+'use client';
+
+import lazy from 'next/dynamic';
+
+const EzViewComponent = lazy(
+  () => import('@atomic/ui-react/ez-view').then(mod => mod.default),
+  {
+    ssr: false,
+  }
+);
+
+export default EzViewComponent;

--- a/packages/ui-next/ez-views/index.ts
+++ b/packages/ui-next/ez-views/index.ts
@@ -1,0 +1,12 @@
+'use client';
+
+import lazy from 'next/dynamic';
+
+const EzViewsComponent = lazy(
+  () => import('@atomic/ui-react/ez-views').then(mod => mod.default),
+  {
+    ssr: false,
+  }
+);
+
+export default EzViewsComponent;

--- a/packages/ui-next/index.ts
+++ b/packages/ui-next/index.ts
@@ -4,3 +4,5 @@ export * from './ez-field/index.js';
 export * from './ez-tab/index.js';
 export * from './ez-tabs/index.js';
 export * from './ez-textfield/index.js';
+export * from './ez-view/index.js';
+export * from './ez-views/index.js';

--- a/packages/ui-next/package.json
+++ b/packages/ui-next/package.json
@@ -44,6 +44,14 @@
       "types": "./dist/ez-tabs/index.d.ts",
       "default": "./dist/ez-tabs/index.js"
     },
+    "./ez-view": {
+      "types": "./dist/ez-view/index.d.ts",
+      "default": "./dist/ez-view/index.js"
+    },
+    "./ez-views": {
+      "types": "./dist/ez-views/index.d.ts",
+      "default": "./dist/ez-views/index.js"
+    },
     "./*": "./dist/*"
   },
   "scripts": {

--- a/packages/ui-react/ez-view/index.ts
+++ b/packages/ui-react/ez-view/index.ts
@@ -1,0 +1,17 @@
+'use client';
+
+import React from 'react';
+import { createComponent } from '@lit/react';
+import { EzViewElement, EzViewEvents } from '@atomic/ui/ez-view';
+
+const EzViewComponent = createComponent({
+  tagName: EzViewElement.localName,
+  elementClass: EzViewElement,
+  react: React,
+  events: {
+    onShow: EzViewEvents.Show,
+    onHide: EzViewEvents.Hide,
+  },
+});
+
+export default EzViewComponent;

--- a/packages/ui-react/ez-views/index.ts
+++ b/packages/ui-react/ez-views/index.ts
@@ -1,0 +1,16 @@
+'use client';
+
+import React from 'react';
+import { createComponent } from '@lit/react';
+import { EzViewsElement, EzViewsEvents } from '@atomic/ui/ez-views';
+
+const EzViewsComponent = createComponent({
+  tagName: EzViewsElement.localName,
+  elementClass: EzViewsElement,
+  react: React,
+  events: {
+    onChange: EzViewsEvents.Change,
+  },
+});
+
+export default EzViewsComponent;

--- a/packages/ui-react/index.ts
+++ b/packages/ui-react/index.ts
@@ -4,3 +4,5 @@ export * from './ez-ripple/index.js';
 export * from './ez-tab/index.js';
 export * from './ez-tabs/index.js';
 export * from './ez-textfield/index.js';
+export * from './ez-view/index.js';
+export * from './ez-views/index.js';

--- a/packages/ui-react/package.json
+++ b/packages/ui-react/package.json
@@ -44,6 +44,14 @@
       "types": "./dist/ez-tabs/index.d.ts",
       "default": "./dist/ez-tabs/index.js"
     },
+    "./ez-view": {
+      "types": "./dist/ez-view/index.d.ts",
+      "default": "./dist/ez-view/index.js"
+    },
+    "./ez-views": {
+      "types": "./dist/ez-views/index.d.ts",
+      "default": "./dist/ez-views/index.js"
+    },
     "./*": "./dist/*"
   },
   "scripts": {

--- a/packages/ui/ez-tab/ez-tab.ts
+++ b/packages/ui/ez-tab/ez-tab.ts
@@ -37,15 +37,24 @@ export class EzTabElement extends EzBaseElement {
   static override properties = {
     ...EzBaseElement.properties,
     active: { type: Boolean, reflect: true },
+    controls: { type: String, reflect: true },
   };
 
   declare active: boolean;
+
+  /**
+   * `id` of the `ez-view` this tab controls (declarative `for` / `controls`
+   * wiring). Mirrored to `aria-controls` so the `tab` -> `tabpanel`
+   * relationship is exposed in the accessibility tree.
+   */
+  declare controls: string;
 
   #internals: ElementInternals;
 
   constructor() {
     super();
     this.active = false;
+    this.controls = '';
 
     // Expose ARIA semantics on the host element itself (not the inner shadow
     // DOM node) so the `tablist` -> `tab` relationship stays intact in the
@@ -60,6 +69,11 @@ export class EzTabElement extends EzBaseElement {
 
     if (changedProperties.has('active')) {
       this.#internals.ariaSelected = this.active ? 'true' : 'false';
+    }
+
+    if (changedProperties.has('controls')) {
+      if (this.controls) this.setAttribute('aria-controls', this.controls);
+      else this.removeAttribute('aria-controls');
     }
   }
 

--- a/packages/ui/ez-tabs/ez-tabs.ts
+++ b/packages/ui/ez-tabs/ez-tabs.ts
@@ -120,11 +120,11 @@ export class EzTabsElement extends EzBaseElement {
 
       if (!tab.id) tab.id = `${this.htmlFor}-tab-${i}`;
 
-      const view = document.getElementById(controls) as
-        | (HTMLElement & { assignTabPanel?: (id: string) => void })
-        | null;
+      const view = document.getElementById(controls);
 
-      view?.assignTabPanel?.(tab.id);
+      (
+        view as { assignTabPanel?: (id: string) => void } | null
+      )?.assignTabPanel?.(tab.id);
     });
 
     // Sync the container to whichever tab is currently active.

--- a/packages/ui/ez-tabs/ez-tabs.ts
+++ b/packages/ui/ez-tabs/ez-tabs.ts
@@ -35,15 +35,25 @@ export class EzTabsElement extends EzBaseElement {
   static override properties = {
     ...EzBaseElement.properties,
     variant: { type: String, reflect: true },
+    htmlFor: { type: String, attribute: 'for', reflect: true },
   };
 
   declare variant: EzTabsVariant | '';
+
+  /**
+   * `id` of the `ez-views` container this tablist drives (declarative wiring).
+   * When set, activating a tab activates the `ez-view` named by that tab's
+   * `controls` attribute, and the ARIA `tab` <-> `tabpanel` relationship is
+   * wired up automatically.
+   */
+  declare htmlFor: string;
 
   #internals: ElementInternals;
 
   constructor() {
     super();
     this.variant = 'primary';
+    this.htmlFor = '';
 
     // Expose the `tablist` role on the host element itself (matching
     // `ez-tab`, which carries `role=tab` via ElementInternals). The inner
@@ -77,6 +87,50 @@ export class EzTabsElement extends EzBaseElement {
     }px)`;
   }
 
+  /** Resolve the associated `ez-views` container, if `for` is set. */
+  #viewsEl(): (HTMLElement & { assignTabPanel?: unknown }) | null {
+    return this.htmlFor ? document.getElementById(this.htmlFor) : null;
+  }
+
+  /**
+   * Activate the `ez-view` controlled by `tab` (upgrade-safe: setting the
+   * `active` attribute works whether or not `ez-views` has upgraded yet).
+   */
+  #driveViews(tab: EzTabElement | null | undefined): void {
+    const container = this.#viewsEl(),
+      controls = tab?.getAttribute('controls');
+
+    if (container && controls) container.setAttribute('active', controls);
+  }
+
+  /**
+   * Wire the ARIA `tab` <-> `tabpanel` relationship: each tab's `controls`
+   * already maps to `aria-controls`; here we generate tab ids where absent and
+   * label each `ez-view` by its controlling tab via `assignTabPanel`.
+   */
+  #wireViews(): void {
+    if (!this.htmlFor) return;
+
+    const tabs = Array.from(this.querySelectorAll<EzTabElement>('ez-tab'));
+
+    tabs.forEach((tab, i) => {
+      const controls = tab.getAttribute('controls');
+
+      if (!controls) return;
+
+      if (!tab.id) tab.id = `${this.htmlFor}-tab-${i}`;
+
+      const view = document.getElementById(controls) as
+        | (HTMLElement & { assignTabPanel?: (id: string) => void })
+        | null;
+
+      view?.assignTabPanel?.(tab.id);
+    });
+
+    // Sync the container to whichever tab is currently active.
+    this.#driveViews(this.querySelector<EzTabElement>('ez-tab[active]'));
+  }
+
   #onTabClick = (e: Event): void => {
     const target = e.target as HTMLElement,
       tab = target.closest<EzTabElement>('ez-tab');
@@ -92,6 +146,7 @@ export class EzTabsElement extends EzBaseElement {
     tab.active = true;
 
     this.#syncIndicator();
+    this.#driveViews(tab);
 
     this.dispatchEvent(
       new CustomEvent(EzTabsEvents.TabChange, {
@@ -138,6 +193,7 @@ export class EzTabsElement extends EzBaseElement {
     nextTab.focus();
 
     this.#syncIndicator();
+    this.#driveViews(nextTab);
 
     this.dispatchEvent(
       new CustomEvent(EzTabsEvents.TabChange, {
@@ -150,6 +206,7 @@ export class EzTabsElement extends EzBaseElement {
 
   #onSlotChange = (): void => {
     this.#syncIndicator();
+    this.#wireViews();
   };
 
   override firstUpdated(_changedProperties: PropertyValues): void {
@@ -170,6 +227,7 @@ export class EzTabsElement extends EzBaseElement {
     this.#resizeObserver.observe(this);
 
     this.#syncIndicator();
+    this.#wireViews();
   }
 
   override disconnectedCallback(): void {

--- a/packages/ui/ez-view/ez-view.scss
+++ b/packages/ui/ez-view/ez-view.scss
@@ -1,0 +1,3 @@
+:host {
+  display: block;
+}

--- a/packages/ui/ez-view/ez-view.ts
+++ b/packages/ui/ez-view/ez-view.ts
@@ -1,0 +1,77 @@
+import { html, type CSSResultGroup, unsafeCSS, type TemplateResult } from 'lit';
+
+import { EzBaseElement } from '../ez-base/ez-base.js';
+
+import cssStr from './ez-view.scss?inline';
+
+const styles = unsafeCSS(cssStr);
+
+export const EzViewName = 'ez-view';
+
+export const EzViewEvents: Record<string, string> = {
+  Show: `${EzViewName}-show`,
+  Hide: `${EzViewName}-hide`,
+};
+
+/**
+ * A single panel within an `ez-views` stack.
+ *
+ * The host's `active` attribute is managed by the parent `ez-views`
+ * (analogous to `[open]` on `<dialog>`). The default show/hide styling lives
+ * in the overridable `views` CSS module — this element never sets inline
+ * `style.display`, so consumers can fully take over via CSS, the
+ * `ez-view-show` / `ez-view-hide` events, or `ez-views`' overridable
+ * `showView` / `hideView` methods.
+ *
+ * The `tabpanel` role is **opt-in**: a tabs driver assigns it (plus an
+ * `aria-labelledby` pointing at the controlling tab) via `assignTabPanel()`;
+ * a wizard/carousel driver leaves it role-less. Role lives on the host via
+ * `ElementInternals` (consistent with `ez-tab`).
+ */
+export class EzViewElement extends EzBaseElement {
+  static localName = EzViewName;
+
+  static override styles: CSSResultGroup = [EzBaseElement.styles, styles];
+
+  static override properties = {
+    ...EzBaseElement.properties,
+    active: { type: Boolean, reflect: true },
+  };
+
+  declare active: boolean;
+
+  #internals: ElementInternals;
+
+  constructor() {
+    super();
+    this.active = false;
+    this.#internals = this.attachInternals();
+  }
+
+  /**
+   * Assign `tabpanel` semantics, labelled by the controlling tab. Called by a
+   * tabs driver (`ez-tabs`) so the ARIA `tab` -> `tabpanel` relationship is
+   * correct without hardcoding tab semantics into the primitive.
+   */
+  assignTabPanel(tabId = ''): void {
+    this.#internals.role = 'tabpanel';
+
+    if (tabId) this.setAttribute('aria-labelledby', tabId);
+  }
+
+  /** Drop any driver-assigned role/labelling. */
+  clearRole(): void {
+    this.#internals.role = null;
+    this.removeAttribute('aria-labelledby');
+  }
+
+  render(): TemplateResult {
+    return html`<slot></slot>`;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'ez-view': EzViewElement;
+  }
+}

--- a/packages/ui/ez-view/index.ts
+++ b/packages/ui/ez-view/index.ts
@@ -1,0 +1,2 @@
+export * from './ez-view.js';
+export * from './register.js';

--- a/packages/ui/ez-view/register.ts
+++ b/packages/ui/ez-view/register.ts
@@ -1,0 +1,4 @@
+import { registerCustomElement } from '../utils/index.js';
+import { EzViewElement } from './ez-view.js';
+
+registerCustomElement(EzViewElement.localName, EzViewElement);

--- a/packages/ui/ez-views/ez-views.scss
+++ b/packages/ui/ez-views/ez-views.scss
@@ -1,0 +1,3 @@
+:host {
+  display: block;
+}

--- a/packages/ui/ez-views/ez-views.stories.ts
+++ b/packages/ui/ez-views/ez-views.stories.ts
@@ -1,0 +1,275 @@
+import { html } from 'lit';
+import { expect } from 'storybook/test';
+import type { StoryObj } from '@storybook/web-components-vite';
+
+import '../ez-tab/register.js';
+import '../ez-tabs/register.js';
+import '../ez-view/register.js';
+import './register.js';
+import { EzViewsName, EzViewsEvents } from './ez-views.js';
+import { EzViewEvents } from '../ez-view/ez-view.js';
+
+export default {
+  title: 'Custom Elements/Views',
+  component: EzViewsName,
+};
+
+type Story = StoryObj;
+
+interface Updatable {
+  updateComplete: Promise<boolean>;
+}
+
+const settle = (el: Element | null | undefined): Promise<boolean> =>
+  (el as unknown as Updatable)?.updateComplete ?? Promise.resolve(true);
+
+/* ─── Standalone stack — switch by id, index, and show() ─────────────────── */
+
+export const StandaloneSwitching: Story = {
+  render: () => html`
+    <section>
+      <header><h2>Standalone View Stack</h2></header>
+
+      <ez-views id="standalone-views">
+        <ez-view id="view-one">First view</ez-view>
+        <ez-view id="view-two">Second view</ez-view>
+        <ez-view id="view-three">Third view</ez-view>
+      </ez-views>
+    </section>
+  `,
+  play: async ({ canvasElement }) => {
+    const views = canvasElement.querySelector<HTMLElement>('ez-views');
+
+    await settle(views);
+
+    const items = Array.from(
+      views?.querySelectorAll<HTMLElement>('ez-view') ?? []
+    );
+
+    await expect(items.length).toBe(3);
+
+    // Defaults to the first view's id.
+    await expect((views as unknown as { active: string }).active).toBe(
+      'view-one'
+    );
+    await expect(items[0]?.hasAttribute('active')).toBe(true);
+    await expect(items[1]?.hasAttribute('active')).toBe(false);
+
+    // Activate by id.
+    (views as unknown as { active: string }).active = 'view-two';
+    await settle(views);
+
+    await expect(items[1]?.hasAttribute('active')).toBe(true);
+    await expect(items[0]?.hasAttribute('active')).toBe(false);
+
+    // Activate by index — kept in sync with `active`.
+    (views as unknown as { selectedIndex: number }).selectedIndex = 2;
+    await settle(views);
+
+    await expect(items[2]?.hasAttribute('active')).toBe(true);
+    await expect((views as unknown as { active: string }).active).toBe(
+      'view-three'
+    );
+    await expect(
+      (views as unknown as { selectedIndex: number }).selectedIndex
+    ).toBe(2);
+
+    // Escape-hatch `show(id)`.
+    (views as unknown as { show: (id: string) => void }).show('view-one');
+    await settle(views);
+
+    await expect(items[0]?.hasAttribute('active')).toBe(true);
+    await expect(items[2]?.hasAttribute('active')).toBe(false);
+  },
+};
+
+/* ─── ez-views-change event + ez-view-show / ez-view-hide lifecycle ──────── */
+
+export const ChangeAndLifecycleEvents: Story = {
+  render: () => html`
+    <section>
+      <header><h2>Change &amp; Lifecycle Events</h2></header>
+
+      <ez-views id="event-views">
+        <ez-view id="ev-one">One</ez-view>
+        <ez-view id="ev-two">Two</ez-view>
+      </ez-views>
+    </section>
+  `,
+  play: async ({ canvasElement }) => {
+    const views = canvasElement.querySelector<HTMLElement>('ez-views');
+
+    await settle(views);
+
+    const items = Array.from(
+      views?.querySelectorAll<HTMLElement>('ez-view') ?? []
+    );
+
+    let changeCount = 0,
+      changeId = '',
+      changeIndex = -1,
+      changeView: Element | null = null,
+      changePrev: Element | null = null,
+      showCount = 0,
+      hideCount = 0;
+
+    views?.addEventListener(EzViewsEvents.Change, (e: Event) => {
+      const detail = (e as CustomEvent).detail as {
+        id: string;
+        index: number;
+        view: Element;
+        prevView: Element | null;
+      };
+
+      changeCount++;
+      changeId = detail.id;
+      changeIndex = detail.index;
+      changeView = detail.view;
+      changePrev = detail.prevView;
+    });
+
+    items[1]?.addEventListener(EzViewEvents.Show, () => {
+      showCount++;
+    });
+    items[0]?.addEventListener(EzViewEvents.Hide, () => {
+      hideCount++;
+    });
+
+    (views as unknown as { active: string }).active = 'ev-two';
+    await settle(views);
+
+    await expect(changeCount).toBe(1);
+    await expect(showCount).toBe(1);
+    await expect(hideCount).toBe(1);
+    await expect(changeId).toBe('ev-two');
+    await expect(changeIndex).toBe(1);
+    await expect(changeView).toBe(items[1]);
+    await expect(changePrev).toBe(items[0]);
+  },
+};
+
+/* ─── Tabs-driven stack — declarative for / controls wiring ──────────────── */
+
+export const TabsDriven: Story = {
+  render: () => html`
+    <section>
+      <header><h2>Tabs-driven View Stack</h2></header>
+
+      <ez-tabs for="posts-views" aria-label="Posts">
+        <ez-tab active controls="post-index">Index</ez-tab>
+        <ez-tab controls="post-create">Create</ez-tab>
+        <ez-tab controls="post-update">Update</ez-tab>
+      </ez-tabs>
+
+      <ez-views id="posts-views">
+        <ez-view id="post-index">Index content</ez-view>
+        <ez-view id="post-create">Create content</ez-view>
+        <ez-view id="post-update">Update content</ez-view>
+      </ez-views>
+    </section>
+  `,
+  play: async ({ canvasElement }) => {
+    const tabs = canvasElement.querySelector<HTMLElement>('ez-tabs'),
+      views = canvasElement.querySelector<HTMLElement>('ez-views');
+
+    await settle(tabs);
+    await settle(views);
+
+    const tabItems = Array.from(
+        tabs?.querySelectorAll<HTMLElement>('ez-tab') ?? []
+      ),
+      viewItems = Array.from(
+        views?.querySelectorAll<HTMLElement>('ez-view') ?? []
+      );
+
+    // Initial active tab drives the matching view.
+    await expect((views as unknown as { active: string }).active).toBe(
+      'post-index'
+    );
+    await expect(viewItems[0]?.hasAttribute('active')).toBe(true);
+
+    // ARIA wiring: tab -> aria-controls, view -> aria-labelledby (tab id).
+    await expect(tabItems[0]?.getAttribute('aria-controls')).toBe('post-index');
+    await expect(tabItems[0]?.id).toBeTruthy();
+    await expect(viewItems[0]?.getAttribute('aria-labelledby')).toBe(
+      tabItems[0]?.id
+    );
+
+    // Clicking a tab activates its controlled view.
+    tabItems[1]?.click();
+    await settle(tabs);
+    await settle(views);
+
+    await expect((views as unknown as { active: string }).active).toBe(
+      'post-create'
+    );
+    await expect(viewItems[1]?.hasAttribute('active')).toBe(true);
+    await expect(viewItems[0]?.hasAttribute('active')).toBe(false);
+  },
+};
+
+/* ─── Lazy — inactive views deferred until first activation ──────────────── */
+
+export const Lazy: Story = {
+  render: () => html`
+    <section>
+      <header><h2>Lazy View Stack</h2></header>
+
+      <ez-views id="lazy-views" lazy>
+        <ez-view id="lazy-one">One</ez-view>
+        <ez-view id="lazy-two">Two</ez-view>
+      </ez-views>
+    </section>
+  `,
+  play: async ({ canvasElement }) => {
+    const views = canvasElement.querySelector<HTMLElement>('ez-views');
+
+    await settle(views);
+
+    // Active view present; inactive view not yet rendered.
+    await expect(views?.querySelector('#lazy-one')).toBeTruthy();
+    await expect(views?.querySelector('#lazy-two')).toBeFalsy();
+
+    (views as unknown as { active: string }).active = 'lazy-two';
+    await settle(views);
+
+    // Now rendered…
+    await expect(views?.querySelector('#lazy-two')).toBeTruthy();
+
+    // …and lazy keeps it mounted after switching away.
+    (views as unknown as { active: string }).active = 'lazy-one';
+    await settle(views);
+
+    await expect(views?.querySelector('#lazy-two')).toBeTruthy();
+  },
+};
+
+/* ─── Destroy-inactive — only the active view stays in the DOM ───────────── */
+
+export const DestroyInactive: Story = {
+  render: () => html`
+    <section>
+      <header><h2>Destroy-inactive View Stack</h2></header>
+
+      <ez-views id="destroy-views" destroy-inactive>
+        <ez-view id="destroy-one">One</ez-view>
+        <ez-view id="destroy-two">Two</ez-view>
+      </ez-views>
+    </section>
+  `,
+  play: async ({ canvasElement }) => {
+    const views = canvasElement.querySelector<HTMLElement>('ez-views');
+
+    await settle(views);
+
+    await expect(views?.querySelector('#destroy-one')).toBeTruthy();
+    await expect(views?.querySelector('#destroy-two')).toBeFalsy();
+
+    (views as unknown as { active: string }).active = 'destroy-two';
+    await settle(views);
+
+    // Previously-active view leaves the DOM; new active view enters.
+    await expect(views?.querySelector('#destroy-two')).toBeTruthy();
+    await expect(views?.querySelector('#destroy-one')).toBeFalsy();
+  },
+};

--- a/packages/ui/ez-views/ez-views.ts
+++ b/packages/ui/ez-views/ez-views.ts
@@ -1,0 +1,316 @@
+import {
+  html,
+  type CSSResultGroup,
+  unsafeCSS,
+  type TemplateResult,
+  type PropertyValues,
+} from 'lit';
+
+import { EzBaseElement } from '../ez-base/ez-base.js';
+import { EzViewElement, EzViewEvents } from '../ez-view/ez-view.js';
+
+import cssStr from './ez-views.scss?inline';
+
+const styles = unsafeCSS(cssStr);
+
+export const EzViewsName = 'ez-views';
+
+export const EzViewsEvents: Record<string, string> = {
+  Change: `${EzViewsName}-change`,
+};
+
+/** Context handed to the overridable `showView` / `hideView` operations. */
+export interface EzViewsContext {
+  prev: EzViewElement | null;
+  next: EzViewElement;
+  index: number;
+  id: string;
+}
+
+let viewIdSeq = 0;
+
+/**
+ * A generic **view-stack** primitive that shows exactly one child `ez-view` at
+ * a time — the content half of the ARIA `tablist → tab → tabpanel` triad.
+ *
+ * It is component-agnostic: `ez-tabs` (via `for` / `controls`), steppers,
+ * wizards, master–detail, etc. drive it as *controllers*; the stack itself
+ * stays neutral.
+ *
+ * The active view is identified by its native **`id`** (`active`); `selectedIndex`
+ * mirrors it by 0-based position. The container drives everything by toggling
+ * the `active` attribute on each `ez-view` (analogous to `[open]` on
+ * `<dialog>`) — it **never** sets inline `style.display`. The default
+ * `display:none` for inactive views lives in the overridable `views` CSS
+ * module, so animation is achievable in userland via three routes: CSS
+ * (`@starting-style` / `allow-discrete`), the `ez-view-show` / `ez-view-hide`
+ * events, or subclassing the overridable `showView` / `hideView` methods.
+ */
+export class EzViewsElement extends EzBaseElement {
+  static localName = EzViewsName;
+
+  static override styles: CSSResultGroup = [EzBaseElement.styles, styles];
+
+  static override properties = {
+    ...EzBaseElement.properties,
+    active: { type: String, reflect: true },
+    lazy: { type: Boolean, reflect: true },
+    destroyInactive: {
+      type: Boolean,
+      attribute: 'destroy-inactive',
+      reflect: true,
+    },
+  };
+
+  /** Active view by `id`. Reflected. */
+  declare active: string;
+
+  /** When set, inactive views are not rendered until first activated. */
+  declare lazy: boolean;
+
+  /** When set, inactive views are removed from the DOM. */
+  declare destroyInactive: boolean;
+
+  #initialized = false;
+
+  #activeView: EzViewElement | null = null;
+
+  /** Detached views (lazy / destroy-inactive), keyed by view -> placeholder. */
+  #anchors = new Map<EzViewElement, Comment>();
+
+  /** Reverse of `#anchors`, for reconstructing order from `childNodes`. */
+  #anchorOf = new Map<Comment, EzViewElement>();
+
+  /** Views that have been shown at least once (lazy keeps these mounted). */
+  #shown = new Set<EzViewElement>();
+
+  constructor() {
+    super();
+    this.active = '';
+    this.lazy = false;
+    this.destroyInactive = false;
+  }
+
+  /* ─── Public API ──────────────────────────────────────────────────────── */
+
+  /** Active view by 0-based index; kept in sync with `active`. */
+  get selectedIndex(): number {
+    return this.#orderedViews().findIndex(v => v.id === this.active);
+  }
+
+  set selectedIndex(n: number) {
+    const view = this.#orderedViews()[n];
+
+    if (view) this.active = view.id;
+  }
+
+  /** Activate a view by `id` (escape hatch for event-driven controllers). */
+  show(id: string): void {
+    this.active = id;
+  }
+
+  /**
+   * Show operation — **overridable**. Default attaches the view (if it was
+   * detached under `lazy` / `destroy-inactive`), toggles the `active`
+   * attribute, and dispatches `ez-view-show`. Override to run animations.
+   */
+  showView(view: EzViewElement, ctx: EzViewsContext): void {
+    this.#attach(view);
+    this.#shown.add(view);
+    view.active = true;
+    view.dispatchEvent(new CustomEvent(EzViewEvents.Show, { detail: ctx }));
+  }
+
+  /**
+   * Hide operation — **overridable**. Default toggles off the `active`
+   * attribute and dispatches `ez-view-hide`. DOM detachment (under
+   * `destroy-inactive` / `lazy`) is reconciled separately so overrides can run
+   * exit animations before the node leaves the tree.
+   */
+  hideView(view: EzViewElement, ctx: EzViewsContext): void {
+    view.active = false;
+    view.dispatchEvent(new CustomEvent(EzViewEvents.Hide, { detail: ctx }));
+  }
+
+  /* ─── Lifecycle ───────────────────────────────────────────────────────── */
+
+  override firstUpdated(changed: PropertyValues): void {
+    super.firstUpdated(changed);
+
+    this.#prepareViews();
+
+    const views = this.#orderedViews();
+
+    let initial = this.active;
+
+    if (!initial) {
+      const siAttr = this.getAttribute('selected-index'),
+        siIndex = siAttr === null ? NaN : Number(siAttr),
+        preset = views.find(v => v.active);
+
+      if (!Number.isNaN(siIndex) && views[siIndex]) {
+        initial = views[siIndex].id;
+      } else {
+        initial = preset?.id ?? views[0]?.id ?? '';
+      }
+    }
+
+    this.active = initial;
+    this.#initialized = true;
+
+    // Activate the initial view without announcing a change (no user action).
+    this.#applyActive(true);
+  }
+
+  override updated(changed: PropertyValues): void {
+    super.updated(changed);
+
+    if (!this.#initialized) return;
+
+    if (
+      changed.has('active') ||
+      changed.has('lazy') ||
+      changed.has('destroyInactive')
+    ) {
+      this.#applyActive(false);
+    }
+  }
+
+  /* ─── Internals ───────────────────────────────────────────────────────── */
+
+  #onSlotChange = (): void => {
+    if (!this.#initialized) return;
+
+    this.#prepareViews();
+    this.#applyActive(true);
+  };
+
+  /** Assign generated ids to any view lacking one (ids are the identifier). */
+  #prepareViews(): void {
+    this.querySelectorAll<EzViewElement>(':scope > ez-view').forEach(view => {
+      if (!view.id) view.id = `ez-view-${++viewIdSeq}`;
+    });
+  }
+
+  /** Ordered view list, including views currently detached via placeholders. */
+  #orderedViews(): EzViewElement[] {
+    const out: EzViewElement[] = [];
+
+    Array.from(this.childNodes).forEach(node => {
+      if (node instanceof EzViewElement) {
+        out.push(node);
+      } else if (node.nodeType === Node.COMMENT_NODE) {
+        const view = this.#anchorOf.get(node as Comment);
+
+        if (view) out.push(view);
+      }
+    });
+
+    return out;
+  }
+
+  #applyActive(silent: boolean): void {
+    const views = this.#orderedViews();
+
+    if (!views.length) return;
+
+    const requested = this.active,
+      next = (requested && views.find(v => v.id === requested)) ?? views[0];
+
+    if (!next) return;
+
+    const prev =
+        this.#activeView && this.#activeView !== next ? this.#activeView : null,
+      alreadyActive =
+        this.#activeView === next && next.active && !this.#anchors.has(next);
+
+    if (alreadyActive) {
+      if (this.active !== next.id) this.active = next.id;
+      this.#reflectIndex();
+      return;
+    }
+
+    const index = views.indexOf(next),
+      ctx: EzViewsContext = { prev, next, index, id: next.id };
+
+    // Hide the previously-active view plus any stray active views.
+    views.forEach(v => {
+      if (v !== next && v.active) this.hideView(v, ctx);
+    });
+
+    this.showView(next, ctx);
+
+    this.#activeView = next;
+
+    if (this.active !== next.id) this.active = next.id;
+
+    this.#reconcileLayout();
+    this.#reflectIndex();
+
+    if (!silent) {
+      this.dispatchEvent(
+        new CustomEvent(EzViewsEvents.Change, {
+          bubbles: true,
+          composed: true,
+          detail: { view: next, prevView: prev, id: next.id, index },
+        })
+      );
+    }
+  }
+
+  /** Detach/attach inactive views per `lazy` / `destroy-inactive`. */
+  #reconcileLayout(): void {
+    this.#orderedViews().forEach(view => {
+      const isActive = view.id === this.active;
+
+      if (isActive) {
+        this.#attach(view);
+      } else if (this.destroyInactive) {
+        this.#detach(view);
+      } else if (this.lazy && !this.#shown.has(view)) {
+        this.#detach(view);
+      } else {
+        this.#attach(view);
+      }
+    });
+  }
+
+  #reflectIndex(): void {
+    const index = this.selectedIndex;
+
+    if (index >= 0) this.setAttribute('selected-index', String(index));
+  }
+
+  /** Remove a view from the DOM, leaving a placeholder to preserve order. */
+  #detach(view: EzViewElement): void {
+    if (this.#anchors.has(view) || view.parentNode !== this) return;
+
+    const anchor = document.createComment(`ez-view:${view.id}`);
+
+    view.replaceWith(anchor);
+    this.#anchors.set(view, anchor);
+    this.#anchorOf.set(anchor, view);
+  }
+
+  /** Re-insert a previously detached view at its placeholder. */
+  #attach(view: EzViewElement): void {
+    const anchor = this.#anchors.get(view);
+
+    if (!anchor) return;
+
+    if (anchor.parentNode) anchor.replaceWith(view);
+
+    this.#anchors.delete(view);
+    this.#anchorOf.delete(anchor);
+  }
+
+  render(): TemplateResult {
+    return html`<slot @slotchange=${this.#onSlotChange}></slot>`;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'ez-views': EzViewsElement;
+  }
+}

--- a/packages/ui/ez-views/index.ts
+++ b/packages/ui/ez-views/index.ts
@@ -1,0 +1,2 @@
+export * from './ez-views.js';
+export * from './register.js';

--- a/packages/ui/ez-views/register.ts
+++ b/packages/ui/ez-views/register.ts
@@ -1,0 +1,4 @@
+import { registerCustomElement } from '../utils/index.js';
+import { EzViewsElement } from './ez-views.js';
+
+registerCustomElement(EzViewsElement.localName, EzViewsElement);

--- a/packages/ui/index.ts
+++ b/packages/ui/index.ts
@@ -6,5 +6,7 @@ export * from './ez-shape/index.js';
 export * from './ez-tab/index.js';
 export * from './ez-tabs/index.js';
 export * from './ez-textfield/index.js';
+export * from './ez-view/index.js';
+export * from './ez-views/index.js';
 export * from './mixins/index.js';
 export * from './utils/index.js';

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -53,6 +53,14 @@
       "types": "./dist/ez-tabs/index.d.ts",
       "default": "./dist/ez-tabs/index.js"
     },
+    "./ez-view": {
+      "types": "./dist/ez-view/index.d.ts",
+      "default": "./dist/ez-view/index.js"
+    },
+    "./ez-views": {
+      "types": "./dist/ez-views/index.d.ts",
+      "default": "./dist/ez-views/index.js"
+    },
     "./utils": {
       "types": "./dist/utils/index.d.ts",
       "default": "./dist/utils/index.js"

--- a/packages/ui/scss/modules/index.scss
+++ b/packages/ui/scss/modules/index.scss
@@ -22,4 +22,5 @@
 @import "menu.scss";
 @import "table.scss";
 @import "tabs.scss";
+@import "views.scss";
 @import "chip/index.scss";

--- a/packages/ui/scss/modules/views.scss
+++ b/packages/ui/scss/modules/views.scss
@@ -1,0 +1,34 @@
+/**
+ * Views (view-stack)
+ *
+ * The content half of the `tablist → tab → tabpanel` triad. `ez-views` shows
+ * one `ez-view` at a time by toggling the `active` attribute (analogous to
+ * `[open]` on `<dialog>`).
+ *
+ * The default show/hide lives here — in the **overridable** user-facing
+ * stylesheet, never inline — so consumers can animate purely in CSS via
+ * `@starting-style` + `transition-behavior: allow-discrete`, e.g.:
+ *
+ *   ez-view {
+ *     opacity: 0;
+ *     transition: opacity .3s, display .3s allow-discrete;
+ *   }
+ *   ez-view[active] { opacity: 1; }
+ *   @starting-style { ez-view[active] { opacity: 0; } }
+ *
+ * The `[active]` / `:not([active])` qualifiers are intentional: they out-weigh
+ * the component's own `:host` display rule so this stylesheet stays the single
+ * source of truth for visibility (and remains overridable by page authors).
+ */
+
+:where(ez-views) {
+  display: block;
+}
+
+ez-view[active] {
+  display: block;
+}
+
+ez-view:not([active]) {
+  display: none;
+}


### PR DESCRIPTION
## Summary

Adds a component-agnostic **view-stack** primitive — **`ez-views`** holding **`ez-view`** children — that shows exactly one active view at a time. This fills the **content half** of the ARIA `tablist → tab → tabpanel` triad: `ez-tabs` (and future steppers/wizards/carousels) drive it as a *controller*, while the stack itself stays neutral.

Closes #121.

## What's included

- **`ez-views`** — `active` (by `id`, reflected), `selectedIndex` (index mirror kept in sync), `lazy`, `destroy-inactive`; `ez-views-change` event; `show()` plus overridable `showView` / `hideView` operations.
- **`ez-view`** — parent-managed `active` attribute; opt-in `tabpanel` role + `aria-labelledby` assigned by a tabs driver via `ElementInternals`; `ez-view-show` / `ez-view-hide` lifecycle events.
- **Animation-ready** — the `display` toggle lives in the overridable `views` CSS module (never inline `style`), so consumers can animate via CSS (`@starting-style` / `allow-discrete`), JS lifecycle events, or `showView`/`hideView` method overrides.
- **Declarative wiring** — `ez-tabs[for]` → views container `id`; `ez-tab[controls]` → `ez-view` `id` (mirrored to `aria-controls`). No consumer event-wiring JS required for the happy path.
- **React wrappers** (`ui-react`) + `ui-next` re-exports; package exports updated.
- **Storybook stories** with `play` functions: standalone switching, change/lifecycle events, tabs-driven wiring, `lazy`, and `destroy-inactive`.

## Verification

- ✅ `pnpm lint` — 7/7 tasks (eslint + stylelint across `ui`, `ui-react`, `ui-site`)
- ✅ `pnpm build` — 4/4 tasks; `ez-views`/`ez-view` compile and bundle cleanly
- `test` skipped (hangs in the worktree environment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)